### PR TITLE
Vih 3986 cleaning out test coverage

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/angular.json
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/angular.json
@@ -81,7 +81,8 @@
             "assets": [
               "src/favicon.ico",
               "src/assets"
-            ]
+            ],
+            "sourceMap": true
           }
         },
         "lint": {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
@@ -30,7 +30,6 @@ export class AppComponent implements OnInit {
     this.loggedIn = false;
     this.initAuthentication();
     pageTracker.trackNavigation(router);
-    pageTracker.trackPreviousPage(router);
   }
 
   private initAuthentication() {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/services/page-tracker.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/services/page-tracker.service.ts
@@ -6,25 +6,12 @@ import 'rxjs/add/operator/pairwise';
 @Injectable()
 export class PageTrackerService {
 
-  PREVIOUS_ROUTE = 'PREVIOUS_ROUTE';
-
   constructor(private logger: AppInsightsLogger) {}
 
   trackNavigation(router: Router) {
     router.events
       .filter(event => event instanceof ResolveEnd)
       .subscribe((event: ResolveEnd) => this.logPageResolved(event));
-  }
-
-  trackPreviousPage(router: Router) {
-    router.events.filter(e => e instanceof NavigationEnd)
-      .pairwise().subscribe((e) => {
-        sessionStorage.setItem(this.PREVIOUS_ROUTE, e[0]['url']);
-      });
-  }
-
-  getPreviousUrl() {
-    return sessionStorage.getItem(this.PREVIOUS_ROUTE);
   }
 
   private logPageResolved(event: ResolveEnd): void {


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
I removed a method from page-tracker that stored the current url but, this was never used so I removed it instead of adding coverage for it.

Then I noticed most classes did have coverage but that the coverage is likely mis-reported due to the missing source maps so I added that.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
