### PR TITLE
Modified the component import

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey-routing.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey-routing.module.ts
@@ -1,9 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-// directives/pipes
-import { LocalisePipe } from './pipes/localise.pipe';
-
 // components
 import { AboutHearingsComponent } from './pages/about-hearings/about-hearings.component';
 import { DifferentHearingTypesComponent } from './pages/different-hearing-types/different-hearing-types.component';
@@ -45,28 +42,29 @@ const routes: Routes = [
   { path: 'media-error', component: MediaErrorComponent }
 ];
 
+// Export all components loaded so these can be declared in parent module
+export const Components = [
+  AboutHearingsComponent,
+  DifferentHearingTypesComponent,
+  ExploreCourtBuildingComponent,
+  CourtBuildingVideoComponent,
+  ExploreVideoHearingComponent,
+  UseCameraMicrophoneComponent,
+  ParticipantViewComponent,
+  JudgeViewComponent,
+  HelpTheCourtDecideComponent,
+  AboutYouComponent,
+  InterpreterComponent,
+  YourComputerComponent,
+  AboutYourComputerComponent,
+  YourInternetConnectionComponent,
+  AccessToRoomComponent,
+  ConsentComponent,
+  ThankYouComponent,
+  MediaErrorComponent
+];
+
 @NgModule({
-  declarations: [
-    LocalisePipe,
-    AboutHearingsComponent,
-    DifferentHearingTypesComponent,
-    ExploreCourtBuildingComponent,
-    CourtBuildingVideoComponent,
-    ExploreVideoHearingComponent,
-    UseCameraMicrophoneComponent,
-    ParticipantViewComponent,
-    JudgeViewComponent,
-    HelpTheCourtDecideComponent,
-    AboutYouComponent,
-    InterpreterComponent,
-    YourComputerComponent,
-    AboutYourComputerComponent,
-    YourInternetConnectionComponent,
-    AccessToRoomComponent,
-    ConsentComponent,
-    ThankYouComponent,
-    MediaErrorComponent
-  ],
   exports: [
     RouterModule
   ],
@@ -74,5 +72,4 @@ const routes: Routes = [
     RouterModule.forChild(routes)
   ],
 })
-export class IndividualJourneyRoutingModule {
-}
+export class IndividualJourneyRoutingModule {}

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.module.ts
@@ -4,7 +4,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 
 // app modules
 import { SharedModule } from '../shared/shared.module';
-import { IndividualJourneyRoutingModule } from './individual-journey-routing.module';
+import { IndividualJourneyRoutingModule, Components } from './individual-journey-routing.module';
 
 // services
 import { Localisation } from 'src/app/modules/shared/localisation';
@@ -18,6 +18,9 @@ import { UserCameraViewComponent } from './components/user-camera-view/user-came
 import { VideoViewComponent } from './components/video-view/video-view.component';
 import { AudioBarComponent } from './components/audio-bar/audio-bar.component';
 
+// directives/pipes
+import { LocalisePipe } from './pipes/localise.pipe';
+
 @NgModule({
   imports: [
     // angular
@@ -30,9 +33,11 @@ import { AudioBarComponent } from './components/audio-bar/audio-bar.component';
     IndividualJourneyRoutingModule,
   ],
   declarations: [
+    ...Components,
     AudioBarComponent,
     UserCameraViewComponent,
-    VideoViewComponent
+    VideoViewComponent,
+    LocalisePipe
   ],
   providers: [
     { provide: Localisation, useClass: IndividualLocalisation },


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
New pattern for component import. By listing them like this in the routing module we can bind them to paths without declaring them in the routing module, this way we don't have to declare their dependencies in the routing module either.

I export the list of components though because doing that allows me to declare them in the other module without importing them.

This means that when adding new components we only need to add them to `individual-journey-routing.module.ts` and they'll be automatically declared in the `individual-journey.module.ts` as well.

This will solve the issue we've seen with having to declare common components in the routing module.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
