### PR TITLE
Updated coverage collection

### DIFF
--- a/ServiceWebsite/ServiceWebsite.UnitTests/ServiceWebsite.UnitTests.csproj
+++ b/ServiceWebsite/ServiceWebsite.UnitTests/ServiceWebsite.UnitTests.csproj
@@ -5,14 +5,20 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.3.0" />
+    <PackageReference Include="coverlet.msbuild" Version="2.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="NBuilder" Version="6.0.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.3.2.6129" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="7.11.0.8083">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="dotnet-reportgenerator-cli" Version="4.0.0-alpha12" />
   </ItemGroup>
     <ItemGroup>

--- a/ServiceWebsite/run_coverage.bat
+++ b/ServiceWebsite/run_coverage.bat
@@ -1,6 +1,6 @@
 rmdir /q /s Artifacts
 
-SET exclude=\"\"
+SET exclude=\"[ServiceWebsite.BookingApi.Client]*,[ServiceWebsite.UserAPI.Client]*,[*]ServiceWebsite.Swagger.*,[ServiceWebsite]ServiceWebsite.Program,[ServiceWebsite]ServiceWebsite.Startup,[ServiceWebsite.IntegrationTests]*,[ServiceWebsite.UnitTests]*\"
 dotnet test ServiceWebsite.UnitTests/ServiceWebsite.UnitTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:CoverletOutput=../Artifacts/Coverage/ /p:MergeWith='../Artifacts/Coverage/coverage.json' /p:Exclude="${exclude}"
 dotnet test ServiceWebsite.IntegrationTests/ServiceWebsite.IntegrationTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:CoverletOutput=../Artifacts/Coverage/ /p:MergeWith='../Artifacts/Coverage/coverage.json' /p:Exclude="${exclude}"
 

--- a/ServiceWebsite/run_coverage.sh
+++ b/ServiceWebsite/run_coverage.sh
@@ -2,7 +2,7 @@
 
 rm -rf Artifacts
 
-exclude=\"\"
+exclude=\"[ServiceWebsite.BookingApi.Client]*,[ServiceWebsite.UserAPI.Client]*,[*]ServiceWebsite.Swagger.*,[ServiceWebsite]ServiceWebsite.Program,[ServiceWebsite]ServiceWebsite.Startup,[ServiceWebsite.IntegrationTests]*,[ServiceWebsite.UnitTests]*\"
 dotnet test ServiceWebsite.UnitTests/ServiceWebsite.UnitTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:CoverletOutput=../Artifacts/Coverage/ /p:MergeWith='../Artifacts/Coverage/coverage.json' /p:Exclude="${exclude}"
 dotnet test ServiceWebsite.IntegrationTests/ServiceWebsite.IntegrationTests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat="\"opencover,cobertura,json,lcov\"" /p:CoverletOutput=../Artifacts/Coverage/ /p:MergeWith='../Artifacts/Coverage/coverage.json' /p:Exclude="${exclude}"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ variables:
     sonar.typescript.lcov.reportPaths=$(System.DefaultWorkingDirectory)/ServiceWebsite/ServiceWebsite/ClientApp/coverage/lcov.info,**/lcov.info
     sonar.typescript.exclusions=**/node_modules/**,**/typings.d.ts,**/main.ts,**/environments/environment*.ts,**/*routing.module.ts,**/api-client.ts
     sonar.cs.opencover.reportsPaths=$(Common.TestResultsDirectory)\Coverage\coverage.opencover.xml
+  coverletCoverageExclusions: '[ServiceWebsite.BookingApi.Client]*,[ServiceWebsite.UserAPI.Client]*,[*]ServiceWebsite.Swagger.*,[ServiceWebsite]ServiceWebsite.Program,[ServiceWebsite]ServiceWebsite.Startup,[ServiceWebsite.IntegrationTests]*,[ServiceWebsite.UnitTests]*'
   integrationTestsAppSettingsTransform: '
   "AzureAd/Authority":"https://login.microsoftonline.com/$(TenantId)",
   "AzureAd/ClientId":"$(vh-service-web-appid)",


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
1. Updated coverage exclusions in `run_coverage` helpers and the azure pipeline, it now excludes unit and integration tests projects
2. Added in correct sonarqube and coverage collection packages to unit test project (I copied those used in the integration test project)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
