### PR TITLE
Switched to using fake stream when running karma tests

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/karma.conf.js
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/karma.conf.js
@@ -37,7 +37,13 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ["Chrome"],
+    browsers: ["ChromeWithFakeStream"],
+    customLaunchers: {
+      ChromeWithFakeStream: {
+        base: 'Chrome',
+        flags: ['--use-fake-ui-for-media-stream', '--use-fake-device-for-media-stream']
+      }
+    },
     singleRun: false
   });
 };


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
Fix to use fake stream when running `ng test` in local chrome browser. This will automatically allow the stream to be used in getUserMedia and return a fake stream.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
