### PR TITLE
Fix for redirect loop on edge by using local storage for token storage

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
@@ -37,11 +37,15 @@ export class AppComponent implements OnInit {
   }
 
   private initAuthentication() {
+    // Required for redirect issue on Edge, it will still create a redirect loop in inPrivate mode
+    // see https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Known-issues-on-Edge
+    const cacheLocation = 'localStorage';
     const config = {
       tenant: this.config.tenantId,
       clientId: this.config.clientId,
       postLogoutRedirectUri: this.config.postLogoutRedirectUri,
       redirectUri: this.config.redirectUri,
+      cacheLocation
     };
 
     this.adalService.init(config);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4478

### Change description ###
Edge has a known issue where the session storage is closed when navigating across security zones, such as when we are running a web page locally or on an intranet and then going to the microsoft login portal. This means that it will effectively clear any information stored for adal tokens when we redirect for login. See further information here:
https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Known-issues-on-Edge
https://stackoverflow.com/questions/46032410/callback-after-login-of-adal-js-is-not-called-in-edge

We can easily solve this by forcing adal.js to store the token information in local storage as in this PR. This leads to a potential security issue where closing the browser will not remove the access token, meaning that if you log in, close the browser and open it again it will automatically log you in.

I believe this issue with login only appears when we are testing locally as that is a different security zone from when we are running towards the actual environments. So, there are three proposals:

1. Add this fix in, take the security risk (after confirming with secops)
2. Ignore the fact that it fails when running locally, adding microsoft login portal to same security zone as localhost
3. Reduce the risk by using `localStorage` only for Edge browser and `sessionStorage` for the other evergreen browsers

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
