### PR TITLE
Raising error on redirect loop

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/app.component.ts
@@ -37,11 +37,11 @@ export class AppComponent implements OnInit {
   }
 
   private initAuthentication() {
-    const config = {
+    const config: adal.Config = {
       tenant: this.config.tenantId,
       clientId: this.config.clientId,
       postLogoutRedirectUri: this.config.postLogoutRedirectUri,
-      redirectUri: this.config.redirectUri,
+      redirectUri: this.config.redirectUri
     };
 
     this.adalService.init(config);

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/security/login/login.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/security/login/login.component.ts
@@ -29,7 +29,21 @@ export class LoginComponent implements OnInit {
     } else {
       const returnUrl = this.route.snapshot.queryParams['returnUrl'] || '/';
       this.returnUrlService.setUrl(returnUrl);
+      this.assertEdgeRedirectIssue(returnUrl);
       this.adalSvc.login();
+    }
+  }
+
+
+  private assertEdgeRedirectIssue(redirectUrl: string): void {
+    // Required for redirect issue on Edge, it doesn't solve the issue but it will let us know when it happens
+    // see https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Known-issues-on-Edge
+    // in summary, when the user tries to log in and has either the login portal or the site itself in a different zone
+    // the session storage will be cleared, meaning the handleWindowCallback is not handling the callback properly
+    // in this method we check if we're trying to login when the id token actually exists in the return url
+    // if this happens it means we've already been redirected back from microsoft login portal, and are looping the login
+    if (redirectUrl.indexOf('#id_token') > -1) {
+      throw new Error('Edge login redirection loop has occured. Please ensure login portal and website are in the same internet zones.');
     }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/Properties/launchSettings.json
+++ b/ServiceWebsite/ServiceWebsite/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://0.0.0.0:50756",
+      "applicationUrl": "http://localhost:50756",
       "sslPort": 44378
     }
   },
@@ -14,7 +14,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://0.0.0.0:5600;http://0.0.0.0:5601"
+      "applicationUrl": "https://localhost:5600;http://localhost:5601"
     },
     "ServiceWebsite": {
       "commandName": "Project",
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://0.0.0.0:5600;http://0.0.0.0:5601"
+      "applicationUrl": "https://localhost:5600;http://localhost:5601"
     }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/Properties/launchSettings.json
+++ b/ServiceWebsite/ServiceWebsite/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:50756",
+      "applicationUrl": "http://0.0.0.0:50756",
       "sslPort": 44378
     }
   },
@@ -14,7 +14,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5600;http://localhost:5601"
+      "applicationUrl": "https://0.0.0.0:5600;http://0.0.0.0:5601"
     },
     "ServiceWebsite": {
       "commandName": "Project",
@@ -22,7 +22,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5600;http://localhost:5601"
+      "applicationUrl": "https://0.0.0.0:5600;http://0.0.0.0:5601"
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4478

### Change description ###
Edge has a known issue where the session storage is closed when navigating across security zones, such as when we are running a web page locally or on an intranet and then going to the microsoft login portal. This means that it will effectively clear any information stored for adal tokens when we redirect for login. See further information here:
https://github.com/AzureAD/azure-activedirectory-library-for-js/wiki/Known-issues-on-Edge
https://stackoverflow.com/questions/46032410/callback-after-login-of-adal-js-is-not-called-in-edge

Round two of fixing this:
Round 1: https://github.com/hmcts/vh-service-web/pull/64

This time around, instead of fixing the issue. We've tracked down and reproduced it. It will only happen when the internet zones are different (or we are in inPrivate mode). Realistically speaking, this should happen very infrequent if ever for the end users. So instead of fixing the issue, I've only put in code to detect it and throw the user to the error page and log the error so we know what happened.

![image](https://user-images.githubusercontent.com/8461739/57361577-a29f3a80-7174-11e9-81b4-b96ad7640bc1.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
