### PR TITLE
Changed order of hooks

### DIFF
--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Hooks/Browser.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Hooks/Browser.cs
@@ -29,7 +29,7 @@ namespace AdminWebsite.AcceptanceTests.Hooks
             return Enum.TryParse(NUnit.Framework.TestContext.Parameters["TargetBrowser"], true, out targetTargetBrowser) ? targetTargetBrowser : TargetBrowser.Chrome;
         }
 
-        [BeforeScenario (Order = 2)]
+        [BeforeScenario (Order = 1)]
         public void BeforeScenario()
         {
             var environment = new SeleniumEnvironment(_saucelabsSettings, _scenarioContext.ScenarioInfo, GetTargetBrowser());

--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Hooks/DataSetUp.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Hooks/DataSetUp.cs
@@ -38,7 +38,7 @@ namespace ServiceWebsite.AcceptanceTests.Hooks
             testContext.VideoAppUrl = configRoot.GetSection("VideoAppUrl").Value;
         }
 
-        [BeforeScenario(Order = 1)]
+        [BeforeScenario(Order = 2)]
         public void CreateNewHearingRequest(TestContext testContext)
         {
                 var requestBody = CreateHearingRequest.BuildRequest(testContext.TestUserSecrets.Individual,testContext.TestUserSecrets.Representative);


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
When making Api calls to create hearing fail, test is not reported in SauceLab.
This is a fix to launch browser in SauceLab before making Api calls to create hearing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
