### PR TITLE
VIH-4618: empty alt attribute to stop the alt text flashing

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/shared/header/header.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/shared/header/header.component.html
@@ -4,7 +4,7 @@
 
       <span class="govuk-header__logotype vh-header-text">
         <img src="/assets/images/UkGovCrestWhite.png" height="32" width="38" class="govuk-header__logotype-crest vh-ml15"
-          alt="HMCTS logo crest image" />
+          alt="" />
         <span class="govuk-header__logotype-text ">
           <span i18n="@@header_logo_1">HM Courts &amp; Tribunals Service</span>
         </span>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/VIH-4618

Changed the alt tag to be empty string so the alt text does not flash when loading page.
As per:
https://webaim.org/standards/wcag/checklist#sc1.1.1
https://webaim.org/standards/508/checklist#standarda



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
