### PR TITLE
Refactor component for textbox form first

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/base-journey.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/base-journey.module.ts
@@ -1,3 +1,4 @@
+import { ChoiceTextboxComponent } from './components/choice-textbox.component';
 import { JourneySelector } from 'src/app/modules/base-journey/services/journey.selector';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
@@ -11,6 +12,9 @@ import { BaseJourneyRoutingModule } from './base-journey-routing.module';
   providers: [
     JourneySelector
   ],
+  declarations: [
+    ChoiceTextboxComponent
+  ],
   imports: [
     // angular
     CommonModule,
@@ -22,6 +26,9 @@ import { BaseJourneyRoutingModule } from './base-journey-routing.module';
     SharedModule,
     BaseJourneyRoutingModule,
   ],
+  exports: [
+    ChoiceTextboxComponent
+  ]
 })
 export class BaseJourneyModule {
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.html
@@ -1,0 +1,58 @@
+<form [formGroup]="form.formGroup" (ngSubmit)="form.submit()">
+  <div id="form-container"
+    [ngClass]="form.isFormInvalid && !form.isTextInputInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
+    <div class="govuk-fieldset">
+      <div *ngIf="form.isFormInvalid && !form.isTextInputInvalid">
+        <span class="govuk-error-message" i18n="@@aboutYou_span_1">
+          Please answer this question
+        </span>
+      </div>
+
+      <ng-content></ng-content>
+
+      <div class="govuk-form-group">
+        <div class="govuk-fieldset fieldset-margin">
+          <div class="govuk-radios">
+
+            <div class="govuk-radios__item">
+              <input formControlName="choice" class="govuk-radios__input" id="choice-yes" type="radio"
+                [value]="true">
+              <label class="govuk-label govuk-radios__label" for="choice-yes" i18n="@@aboutYou_label_1">
+                Yes
+              </label>
+            </div>
+            <div [ngClass]="form.isTextInputInvalid ? 'vh-radios__conditional--error' : 'govuk-radios__conditional'">
+              <div class="form-group textarea-top-margin" *ngIf="form.choice.value">
+                <div>
+                  <span *ngIf="form.isTextInputInvalid" class="govuk-error-message" i18n="@@aboutYou_span_2">
+                    Please complete this section
+                  </span>
+                  <label for="details" id="more-details" class="govuk-label" i18n="@@aboutYou_label_1">
+                    Please provide more information
+                  </label>
+                  <textarea formControlName="textInput" class="txtMore vh-text-width" id="details" rows="5"
+                    cols="80" [ngClass]="form.isTextInputInvalid ? 'govuk-textarea--error' : 'govuk-textarea'"
+                    aria-describedby="more-details">
+                  </textarea>
+                </div>
+              </div>
+            </div>
+
+            <div class="govuk-radios__item">
+              <input formControlName="choice" class="govuk-radios__input" id="choice-no" type="radio"
+                [value]="false">
+              <label class="govuk-label govuk-radios__label" for="choice-no" i18n="@@aboutYou_label_2">
+                No
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-20">
+    <button class="govuk-button" (click)="form.submit()" i18n="@@aboutYou_btn_continue" id="continue"
+      type="button">Continue</button>
+  </div>
+</form>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.html
@@ -3,7 +3,7 @@
     [ngClass]="form.isFormInvalid && !form.isTextInputInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
     <div class="govuk-fieldset">
       <div *ngIf="form.isFormInvalid && !form.isTextInputInvalid">
-        <span class="govuk-error-message" i18n="@@aboutYou_span_1">
+        <span class="govuk-error-message" i18n="@@choiceTextbox_span_1">
           Please answer this question
         </span>
       </div>
@@ -17,17 +17,17 @@
             <div class="govuk-radios__item">
               <input formControlName="choice" class="govuk-radios__input" id="choice-yes" type="radio"
                 [value]="true">
-              <label class="govuk-label govuk-radios__label" for="choice-yes" i18n="@@aboutYou_label_1">
+              <label class="govuk-label govuk-radios__label" for="choice-yes" i18n="@@choiceTextbox_label_1">
                 Yes
               </label>
             </div>
             <div [ngClass]="form.isTextInputInvalid ? 'vh-radios__conditional--error' : 'govuk-radios__conditional'">
               <div class="form-group textarea-top-margin" *ngIf="form.choice.value">
                 <div>
-                  <span *ngIf="form.isTextInputInvalid" class="govuk-error-message" i18n="@@aboutYou_span_2">
+                  <span *ngIf="form.isTextInputInvalid" class="govuk-error-message" i18n="@@choiceTextbox_span_2">
                     Please complete this section
                   </span>
-                  <label for="details" id="more-details" class="govuk-label" i18n="@@aboutYou_label_1">
+                  <label for="details" id="more-details" class="govuk-label" i18n="@@choiceTextbox_label_1">
                     Please provide more information
                   </label>
                   <textarea formControlName="textInput" class="txtMore vh-text-width" id="details" rows="5"
@@ -41,7 +41,7 @@
             <div class="govuk-radios__item">
               <input formControlName="choice" class="govuk-radios__input" id="choice-no" type="radio"
                 [value]="false">
-              <label class="govuk-label govuk-radios__label" for="choice-no" i18n="@@aboutYou_label_2">
+              <label class="govuk-label govuk-radios__label" for="choice-no" i18n="@@choiceTextbox_label_2">
                 No
               </label>
             </div>
@@ -52,7 +52,7 @@
   </div>
 
   <div class="mt-20">
-    <button class="govuk-button" (click)="form.submit()" i18n="@@aboutYou_btn_continue" id="continue"
+    <button class="govuk-button" (click)="form.submit()" i18n="@@choiceTextbox_btn_continue" id="continue"
       type="button">Continue</button>
   </div>
 </form>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.spec.ts
@@ -1,0 +1,103 @@
+import { SuitabilityChoiceComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
+import { ChoiceTextboxComponent } from './choice-textbox.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SuitabilityAnswer } from '../participant-suitability.model';
+import { ReactiveFormsModule } from '@angular/forms';
+
+describe('ChoiceTextboxComponent', () => {
+  let component: ChoiceTextboxComponent;
+  let fixture: ComponentFixture<ChoiceTextboxComponent>;
+  let testFixture: SuitabilityChoiceComponentFixture;
+  let answer: SuitabilityAnswer;
+  let submitted = false;
+
+  beforeEach(() => {
+    answer = new SuitabilityAnswer();
+
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule
+      ],
+      declarations: [
+        ChoiceTextboxComponent
+      ]
+    });
+
+    fixture = TestBed.createComponent(ChoiceTextboxComponent);
+    component = fixture.componentInstance;
+    component.suitabilityAnswer = answer;
+    component.submitted.subscribe(() => submitted = true);
+
+    fixture.detectChanges();
+    component.ngOnInit();
+
+    testFixture = new SuitabilityChoiceComponentFixture(fixture);
+  });
+
+  it('cannot proceed to next step before selecting a choice', () => {
+    // when
+    testFixture.submitIsClicked();
+
+    // then
+    expect(component.form.isFormInvalid).toBeTruthy();
+
+    // expect form to display error class
+    const formContainer = testFixture.debugElementByCss('#form-container');
+    expect(formContainer.classes['govuk-form-group--error']).toBeTruthy();
+
+    // and error message to be displayed
+    const errorMessage = testFixture.debugElementByCss('#form-container .govuk-error-message');
+    expect(errorMessage.nativeElement).toBeTruthy();
+  });
+
+  it('should clear error when selecting no', () => {
+    testFixture.submitIsClicked();
+    testFixture.radioBoxIsClicked('#choice-no');
+    expect(component.form.isFormInvalid).toBeFalsy();
+  });
+
+  it('should clear error when selecting yes after having submitted', () => {
+    testFixture.submitIsClicked();
+    testFixture.radioBoxIsClicked('#choice-yes');
+    expect(component.form.isFormInvalid).toBeFalsy();
+  });
+
+  it('should display text field when selecting yes', () => {
+    testFixture.radioBoxIsClicked('#choice-yes');
+    expect(component.form.isFormInvalid).toBeFalsy();
+  });
+
+  it('should be invalid if submitting without having entered any text', () => {
+    // when
+    testFixture.radioBoxIsClicked('#choice-yes');
+    testFixture.submitIsClicked();
+
+    // then
+    expect(component.form.isFormInvalid).toBeTruthy();
+    const textfield = testFixture.debugElementByCss('#details');
+    expect(textfield.classes['govuk-textarea--error']).toBeTruthy();
+  });
+
+  it('should bind value and notes to model on submit', () => {
+    // when
+    testFixture.radioBoxIsClicked('#choice-yes');
+    component.form.textInput.setValue('notes');
+    testFixture.detectChanges();
+    testFixture.submitIsClicked();
+
+    // then
+    expect(answer.answer).toBe(true);
+    expect(answer.notes).toBe('notes');
+  });
+
+  it('should bind notes as null on selecting no', () => {
+    // when
+    testFixture.radioBoxIsClicked('#choice-no');
+    testFixture.detectChanges();
+    testFixture.submitIsClicked();
+
+    // then
+    expect(answer.answer).toBe(false);
+    expect(answer.notes).toBeNull();
+  });
+});

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/choice-textbox.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { ChoiceTextboxForm } from './choice-textbox-form';
+import { SuitabilityAnswer } from '../participant-suitability.model';
+
+@Component({
+    selector: 'app-choice-textbox',
+    templateUrl: './choice-textbox.component.html'
+  })
+  export class ChoiceTextboxComponent implements OnInit {
+
+    @Input()
+    suitabilityAnswer: SuitabilityAnswer;
+
+    @Output()
+    submitted = new EventEmitter();
+
+    readonly form = new ChoiceTextboxForm();
+
+    ngOnInit() {
+      this.form.submitted.subscribe(() => this.onSubmitted());
+      this.form.choice.setValue(this.suitabilityAnswer.answer);
+      this.form.textInput.setValue(this.suitabilityAnswer.notes);
+    }
+
+    protected onSubmitted(): void {
+      this.suitabilityAnswer.answer = this.form.choice.value;
+      this.suitabilityAnswer.notes = this.form.choice.value ? this.form.textInput.value : null;
+      this.submitted.emit();
+    }
+  }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.module.ts
@@ -1,3 +1,4 @@
+import { BaseJourneyModule } from './../base-journey/base-journey.module';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -40,6 +41,7 @@ import { VideoUrlService } from './services/video-url.service';
 
     // app
     SharedModule,
+    BaseJourneyModule,
     IndividualJourneyRoutingModule,
   ],
   declarations: [

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.html
@@ -4,81 +4,26 @@
       About you
     </h1>
 
-    <form [formGroup]="form.formGroup" (ngSubmit)="form.submit()">
+    <app-choice-textbox [suitabilityAnswer]="journey.model.aboutYou" (submitted)="journey.next()">
+      <p class="govuk-body govuk-!-margin-bottom-6" i18n="@@aboutYou_p_1">
+        Is there anything you’d like the court to take into account when it decides which type of hearing will be
+        suitable?
+      </p>
 
-      <div id="form-container"
-        [ngClass]="form.isFormInvalid && !form.isTextInputInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
-        <div class="govuk-fieldset">
-          <div *ngIf="form.isFormInvalid && !form.isTextInputInvalid">
-            <span class="govuk-error-message" i18n="@@aboutYou_span_1">
-              Please answer this question
-            </span>
-          </div>
+      <p class="govuk-body govuk-!-margin-bottom-1" i18n="@@aboutYou_p_2">
+        For example:
+      </p>
 
-          <p class="govuk-body govuk-!-margin-bottom-6" i18n="@@aboutYou_p_1">
-            Is there anything you’d like the court to take into account when it decides which type of hearing will be
-            suitable?
-          </p>
-
-          <p class="govuk-body govuk-!-margin-bottom-1" i18n="@@aboutYou_p_2">
-            For example:
-          </p>
-
-          <ul class="govuk-list govuk-list--bullet">
-            <li i18n="@@aboutYou_listItem_1">are you hard of hearing or deaf?</li>
-            <li i18n="@@aboutYou_listItem_2">are you blind or partially sighted?</li>
-            <li i18n="@@aboutYou_listItem_3">do you have a learning disability or sometimes struggle to understand
-              everyday things?</li>
-            <li i18n="@@aboutYou_listItem_4">do you have mobility issues that make it difficult to travel?</li>
-            <li i18n="@@aboutYou_listItem_5">something else?</li>
-          </ul>
-
-          <div class="govuk-form-group">
-            <div class="govuk-fieldset fieldset-margin">
-              <div class="govuk-radios">
-
-                <div class="govuk-radios__item">
-                  <input formControlName="choice" class="govuk-radios__input" id="choice-yes" type="radio"
-                    [value]="true">
-                  <label class="govuk-label govuk-radios__label" for="choice-yes" i18n="@@aboutYou_label_1">
-                    Yes
-                  </label>
-                </div>
-                <div [ngClass]="form.isTextInputInvalid ? 'vh-radios__conditional--error' : 'govuk-radios__conditional'">
-                  <div class="form-group textarea-top-margin" *ngIf="form.choice.value">
-                    <div>
-                      <span *ngIf="form.isTextInputInvalid" class="govuk-error-message" i18n="@@aboutYou_span_2">
-                        Please complete this section
-                      </span>
-                      <label for="details" id="more-details" class="govuk-label" i18n="@@aboutYou_label_1">
-                        Please provide more information
-                      </label>
-                      <textarea formControlName="textInput" class="txtMore vh-text-width" id="details" rows="5"
-                        cols="80" [ngClass]="form.isTextInputInvalid ? 'govuk-textarea--error' : 'govuk-textarea'"
-                        aria-describedby="more-details">
-                      </textarea>
-                    </div>
-                  </div>
-                </div>
-
-                <div class="govuk-radios__item">
-                  <input formControlName="choice" class="govuk-radios__input" id="choice-no" type="radio"
-                    [value]="false">
-                  <label class="govuk-label govuk-radios__label" for="choice-no" i18n="@@aboutYou_label_2">
-                    No
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="mt-20">
-        <button class="govuk-button" (click)="form.submit()" i18n="@@aboutYou_btn_continue" id="continue"
-          type="button">Continue</button>
-      </div>
-    </form>
+      <ul class="govuk-list govuk-list--bullet">
+        <li i18n="@@aboutYou_listItem_1">are you hard of hearing or deaf?</li>
+        <li i18n="@@aboutYou_listItem_2">are you blind or partially sighted?</li>
+        <li i18n="@@aboutYou_listItem_3">do you have a learning disability or sometimes struggle to understand
+          everyday things?</li>
+        <li i18n="@@aboutYou_listItem_4">do you have mobility issues that make it difficult to travel?</li>
+        <li i18n="@@aboutYou_listItem_5">something else?</li>
+      </ul>
+    </app-choice-textbox>
+    
     <app-contact-us></app-contact-us>
   </div>
 </div>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.spec.ts
@@ -1,88 +1,32 @@
-import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
+import { ChoiceTextboxComponent } from './../../../base-journey/components/choice-textbox.component';
+import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../individual-base-component/individual-component-test-bed.spec';
 import { SuitabilityChoiceComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
 import { AboutYouComponent } from './about-you.component';
+import { IndividualJourney } from '../../individual-journey';
 
 describe('AboutYouComponent', () => {
   let fixture: SuitabilityChoiceComponentFixture;
   let component: AboutYouComponent;
+  let journey: jasmine.SpyObj<IndividualJourney>;
 
   beforeEach(() => {
+    journey = IndividualJourneyStubs.journeySpy;
     const componentFixture = IndividualJourneyComponentTestBed.createComponent({
-      component: AboutYouComponent
+      component: AboutYouComponent,
+      declarations: [
+        ChoiceTextboxComponent
+      ],
+      journey: journey
     });
     component = componentFixture.componentInstance;
     fixture = new SuitabilityChoiceComponentFixture(componentFixture);
     fixture.detectChanges();
-    component.ngOnInit();
-
-    component = componentFixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('cannot proceed to next step before selecting a choice', () => {
-    // when
-    fixture.submitIsClicked();
-
-    // then
-    expect(component.form.isFormInvalid).toBeTruthy();
-
-    // expect form to display error class
-    const formContainer = fixture.debugElementByCss('#form-container');
-    expect(formContainer.classes['govuk-form-group--error']).toBeTruthy();
-
-    // and error message to be displayed
-    const errorMessage = fixture.debugElementByCss('#form-container .govuk-error-message');
-    expect(errorMessage.nativeElement).toBeTruthy();
-  });
-
-  it('should clear error when selecting no', () => {
-    fixture.submitIsClicked();
+  it('binds values and goes to next step after selecting choice and choosing continue', () => {
     fixture.radioBoxIsClicked('#choice-no');
-    expect(component.form.isFormInvalid).toBeFalsy();
-  });
-
-  it('should clear error when selecting yes after having submitted', () => {
     fixture.submitIsClicked();
-    fixture.radioBoxIsClicked('#choice-yes');
-    expect(component.form.isFormInvalid).toBeFalsy();
-  });
-
-  it('should display text field when selecting yes', () => {
-    fixture.radioBoxIsClicked('#choice-yes');
-    expect(component.form.isFormInvalid).toBeFalsy();
-  });
-
-  it('should be invalid if submitting without having entered any text', () => {
-    // when
-    fixture.radioBoxIsClicked('#choice-yes');
-    fixture.submitIsClicked();
-
-    // then
-    expect(component.form.isFormInvalid).toBeTruthy();
-    const textfield = fixture.debugElementByCss('#details');
-    expect(textfield.classes['govuk-textarea--error']).toBeTruthy();
-  });
-
-  it('should bind value and notes to model on submit', () => {
-    // when
-    fixture.radioBoxIsClicked('#choice-yes');
-    component.form.textInput.setValue('notes');
-    fixture.detectChanges();
-    fixture.submitIsClicked();
-
-    // then
-    expect(component.journey.model.aboutYou.answer).toBe(true);
-    expect(component.journey.model.aboutYou.notes).toBe('notes');
-  });
-
-  it('should bind notes as null on selecting no', () => {
-    // when
-    fixture.radioBoxIsClicked('#choice-no');
-    fixture.detectChanges();
-    fixture.submitIsClicked();
-
-    // then
-    expect(component.journey.model.aboutYou.answer).toBe(false);
-    expect(component.journey.model.aboutYou.notes).toBeNull();
+    expect(journey.model.aboutYou.answer).toBe(false);
+    expect(journey.next).toHaveBeenCalled();
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
@@ -6,24 +6,11 @@ import { ChoiceTextboxForm } from 'src/app/modules/base-journey/components/choic
   selector: 'app-about-you',
   templateUrl: './about-you.component.html'
 })
-export class AboutYouComponent implements OnInit {
+export class AboutYouComponent {
 
-  readonly form = new ChoiceTextboxForm();
   readonly journey: IndividualJourney;
 
   constructor(journey: IndividualJourney) {
     this.journey = journey;
-  }
-
-  ngOnInit() {
-    this.form.submitted.subscribe(() => this.continue());
-    this.form.choice.setValue(this.journey.model.aboutYou.answer);
-    this.form.textInput.setValue(this.journey.model.aboutYou.notes);
-  }
-
-  protected continue(): void {
-    this.journey.model.aboutYou.answer = this.form.choice.value;
-    this.journey.model.aboutYou.notes = this.form.choice.value ? this.form.textInput.value : null;
-    this.journey.next();
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { IndividualJourney } from '../../individual-journey';
-import { ChoiceTextboxForm } from 'src/app/modules/base-journey/components/choice-textbox-form';
 
 @Component({
   selector: 'app-about-you',


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
The first of four components to use a common component that wraps the validation and output of a form. The component uses the `<ng-content>` content projector. This lets us place some page specific content straight into the form making it reusable, see [https://angular.io/api/common/NgComponentOutlet](https://angular.io/api/common/NgComponentOutlet).

I found that the actual form and how we bind to it is identical to these for components and it bugged me how we have a huge set of tests testing the exact same functionality four times.

In this PR I only update one of them because it still includes *a lot* of changes and I wanted to keep the PR smaller. I'll PR the remaining three components separately.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
