### PR TITLE
Refactored to make the submit service agnostic to the order of steps

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
@@ -78,7 +78,7 @@ export class IndividualJourney extends JourneyBase {
     if (this.submitService.isDropOffPoint(this.model)) {
       // update the model to set the answers in case browserback was clicked and the answers were changed.
       let saveModel: MutableIndividualSuitabilityModel;
-      saveModel = this.submitService.updateSubmitModel(currentStep, this.model);
+      saveModel = this.submitService.updateSubmitModel(this.currentStep, this.model);
       // save the updated model.
       this.submitService.submit(saveModel);
       this.isSubmitted = true;

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/submit.service.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/submit.service.spec.ts
@@ -2,6 +2,7 @@ import { SubmitService } from './submit.service';
 import { MutableIndividualSuitabilityModel } from '../mutable-individual-suitability.model';
 import { Hearing, HasAccessToCamera } from '../../base-journey/participant-suitability.model';
 import { SuitabilityService } from './suitability.service';
+import { IndividualJourneySteps } from '../individual-journey-steps';
 
 describe('SubmitService', () => {
   const suitabilityService = jasmine.createSpyObj<SuitabilityService>(['updateSuitabilityAnswers']);
@@ -71,7 +72,7 @@ describe('SubmitService', () => {
   });
   it('should clear the answers after the drop off point - access to computer', () => {
     model.computer = false;
-    const saveModel = submitService.updateSubmitModel(10, model);
+    const saveModel = submitService.updateSubmitModel(IndividualJourneySteps.AccessToComputer, model);
 
     expect(saveModel.camera).toBe(undefined);
     expect(saveModel.internet).toBe(undefined);
@@ -83,7 +84,7 @@ describe('SubmitService', () => {
   it('should clear the answers after the drop off point - access to camera', () => {
     model.computer = true;
     model.camera = HasAccessToCamera.No;
-    const saveModel = submitService.updateSubmitModel(11, model);
+    const saveModel = submitService.updateSubmitModel(IndividualJourneySteps.AccessToCameraAndMicrophone, model);
 
     expect(saveModel.internet).toBe(undefined);
     expect(saveModel.room).toBe(undefined);
@@ -94,7 +95,7 @@ describe('SubmitService', () => {
     model.computer = true;
     model.camera = HasAccessToCamera.No;
     model.internet = false;
-    const saveModel = submitService.updateSubmitModel(12, model);
+    const saveModel = submitService.updateSubmitModel(IndividualJourneySteps.YourInternetConnection, model);
 
     expect(saveModel.room).toBe(undefined);
     expect(saveModel.consent.answer).toBe(undefined);

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/submit.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/submit.service.ts
@@ -5,6 +5,8 @@ import { SuitabilityService } from './suitability.service';
 import { SuitabilityAnswer, HasAccessToCamera } from '../../base-journey/participant-suitability.model';
 import { IndividualSuitabilityModel } from '../individual-suitability.model';
 import { MutableIndividualSuitabilityModel } from '../mutable-individual-suitability.model';
+import { JourneyStep } from '../../base-journey/journey-step';
+import { IndividualJourneySteps } from '../individual-journey-steps';
 
 @Injectable()
 export class SubmitService {
@@ -36,36 +38,26 @@ export class SubmitService {
     return false;
   }
 
-  updateSubmitModel(step: number, model: IndividualSuitabilityModel): MutableIndividualSuitabilityModel {
+  updateSubmitModel(step: JourneyStep, model: IndividualSuitabilityModel): MutableIndividualSuitabilityModel {
     let modelToSave = new MutableIndividualSuitabilityModel();
     modelToSave = model;
-    switch (step) {
-      case 10: {
+
+    if (step === IndividualJourneySteps.AccessToComputer) {
         modelToSave.camera = undefined;
         modelToSave.internet = undefined;
         modelToSave.room = undefined;
         modelToSave.consent = new SuitabilityAnswer();
-
-        break;
-      }
-      case 11: {
+    } else if (step === IndividualJourneySteps.AccessToCameraAndMicrophone) {
         modelToSave.internet = undefined;
         modelToSave.room = undefined;
         modelToSave.consent = new SuitabilityAnswer();
-
-        break;
-      }
-      case 12: {
+    } else if (step === IndividualJourneySteps.YourInternetConnection) {
         modelToSave.room = undefined;
         modelToSave.consent = new SuitabilityAnswer();
-
-        break;
-      }
-      default: {
-        console.log('not an exit step, do nothing');
-        break;
-      }
     }
+
+    // for any other step the model need not be updated
+
     return modelToSave;
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
When being implemented the SubmitService for IndividualJourney got dependent on the ordering of steps by referencing them using magical numbers instead of the static accessors.

I've updated this so the functionality is the same but it is using the steps and not their indexes instead.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
