### PR TITLE
VIH-4577 Added new fields

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/participant-suitability.model.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/participant-suitability.model.ts
@@ -9,6 +9,28 @@ export enum HasAccessToCamera {
     NotSure
 }
 
+export class SelfTestAnswers {
+    constructor(answers?: {
+        seeAndHearClearly?: boolean,
+        sameComputer?: boolean,
+        cameraWorking?: boolean,
+        microphoneWorking?: boolean
+    }) {
+        if (answers) {
+            this.seeAndHearClearly = answers.seeAndHearClearly;
+            this.sameComputer = answers.sameComputer;
+            this.cameraWorking = answers.cameraWorking;
+            this.microphoneWorking = answers.microphoneWorking;
+        }
+    }
+
+    seeAndHearClearly: boolean;
+    sameComputer: boolean;
+    cameraWorking: boolean;
+    microphoneWorking: boolean;
+}
+
+
 /**
  * Exposes the basic properties of the suitability model.
  */
@@ -17,6 +39,9 @@ export abstract class ParticipantSuitabilityModel {
     camera: HasAccessToCamera;
     computer: boolean;
     room: boolean;
+
+    selfTest: SelfTestAnswers;
+
     hearing: Hearing;
 
     isUpcoming(): boolean {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/individual-journey.service.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/individual-journey.service.spec.ts
@@ -1,3 +1,4 @@
+import { SelfTestAnswers } from './../../base-journey/participant-suitability.model';
 import { IndividualJourneyService } from './individual-journey.service';
 import { MutableIndividualSuitabilityModel } from '../mutable-individual-suitability.model';
 import { HasAccessToCamera, Hearing, SuitabilityAnswer } from '../../base-journey/participant-suitability.model';
@@ -27,6 +28,13 @@ describe('representative.journey.service', () => {
     model.room = true;
     model.camera = HasAccessToCamera.NotSure;
     model.computer = true;
+
+    model.selfTest = new SelfTestAnswers({
+      seeAndHearClearly: true,
+      cameraWorking: false,
+      sameComputer: true,
+      microphoneWorking: false
+    });
 
     individualJourneyService.set(model);
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/individual-journey.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/services/individual-journey.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { SessionStorage } from '../../shared/services/session-storage';
-import { Hearing } from '../../base-journey/participant-suitability.model';
+import { Hearing, SelfTestAnswers } from '../../base-journey/participant-suitability.model';
 import { MutableIndividualSuitabilityModel } from '../mutable-individual-suitability.model';
 import { IndividualSuitabilityModel } from '../individual-suitability.model';
 
@@ -31,6 +31,8 @@ export class IndividualJourneyService {
     model.room = response.room;
     model.camera = response.camera;
     model.computer = response.computer;
+
+    model.selfTest = new SelfTestAnswers(response.selfTest);
 
     return model;
   }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/representative.journey.service.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/representative.journey.service.spec.ts
@@ -1,6 +1,6 @@
 import {RepresentativeJourneyService} from './representative.journey.service';
 import {MutableRepresentativeSuitabilityModel} from '../mutable-representative-suitability.model';
-import {HasAccessToCamera, Hearing, SuitabilityAnswer} from '../../base-journey/participant-suitability.model';
+import {HasAccessToCamera, Hearing, SuitabilityAnswer, SelfTestAnswers} from '../../base-journey/participant-suitability.model';
 
 describe('representative.journey.service', () => {
   let representativeJourneyService: RepresentativeJourneyService;
@@ -29,6 +29,13 @@ describe('representative.journey.service', () => {
     model.room = true;
     model.camera = HasAccessToCamera.NotSure;
     model.computer = true;
+
+    model.selfTest = new SelfTestAnswers({
+      seeAndHearClearly: false,
+      sameComputer: true,
+      cameraWorking: false,
+      microphoneWorking: true
+    });
 
     representativeJourneyService.set(model);
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/representative.journey.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/representative.journey.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { SessionStorage } from '../../shared/services/session-storage';
 import { RepresentativeSuitabilityModel } from '../representative-suitability.model';
-import { Hearing } from '../../base-journey/participant-suitability.model';
+import { Hearing, SelfTestAnswers } from '../../base-journey/participant-suitability.model';
 import { MutableRepresentativeSuitabilityModel } from '../mutable-representative-suitability.model';
 
 @Injectable()
@@ -31,6 +31,8 @@ export class RepresentativeJourneyService {
     model.room = response.room;
     model.camera = response.camera;
     model.computer = response.computer;
+
+    model.selfTest = new SelfTestAnswers(response.selfTest);
 
     return model;
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4577

### Change description ###
Added in the new fields to participant suitability model for self-test journey.

There are four new fields, one I think will only be used during the journey (`sameComputer`) to direct the user to log out if it's set to `false` so it won't need to be mapped, still, as we use these values to guide the journey I figured it makes sense to add it to the model. (thoughts?)

I also added in tests for the mapping for both rep and individual so that it's not forgotten.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
