### PR TITLE
Improvement to saucelabs run name

### DIFF
--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Helpers/SeleniumEnvironment.cs
@@ -86,7 +86,7 @@ namespace ServiceWebsite.AcceptanceTests.Helpers
             }
 
             caps.SetCapability("name", _scenario.Title);
-            caps.SetCapability("build", Environment.GetEnvironmentVariable("Build_DefinitionName") + "  " + Environment.GetEnvironmentVariable("BUILD_BUILDNUMBER"));
+            caps.SetCapability("build", $"{Environment.GetEnvironmentVariable("Build_DefinitionName")} {Environment.GetEnvironmentVariable("RELEASE_RELEASENAME")}");
 #pragma warning restore 618
 
             // It can take quite a bit of time for some commands to execute remotely so this is higher than default


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
As per [the admin web PR](https://github.com/hmcts/vh-admin-web/pull/112) I've added in so that the run name now contains the release name instead of the build name in saucelabs. This makes each individual run/deployment get reported separately and easier to find.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
