### PR TITLE
Rewrote so that self test components use base journey

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/base-journey.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/base-journey.module.ts
@@ -1,3 +1,5 @@
+import { ParticipantSuitabilityModel } from 'src/app/modules/base-journey/participant-suitability.model';
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import { ChoiceTextboxComponent } from './components/choice-textbox.component';
 import { JourneySelector } from 'src/app/modules/base-journey/services/journey.selector';
 import { CommonModule } from '@angular/common';
@@ -10,7 +12,17 @@ import { BaseJourneyRoutingModule } from './base-journey-routing.module';
 
 @NgModule({
   providers: [
-    JourneySelector
+    JourneySelector,
+    {
+      provide: JourneyBase,
+      useFactory: (selector: JourneySelector) => selector.getJourney(),
+      deps: [ JourneySelector ]
+    },
+    {
+      provide: ParticipantSuitabilityModel,
+      useFactory: (selector: JourneySelector) => selector.getModel(),
+      deps: [ JourneySelector ]
+    }
   ],
   declarations: [
     ChoiceTextboxComponent

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.factory.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.factory.ts
@@ -1,12 +1,20 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
+import { ParticipantSuitabilityModel } from '../participant-suitability.model';
+
 export interface JourneyFactory {
     /**
      * Begin the journey
      */
-    begin(): Promise<void>;
+    begin(): Promise<JourneyBase>;
 
     /**
      * Checks if the factory applies to users of the given type
      * @param userType Type of user to test if the factory supplies journeys for
      */
     handles(userType: string): boolean;
+
+    /**
+     * Get the current journey participant model
+     */
+    getModel(): ParticipantSuitabilityModel;
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.selector.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.selector.ts
@@ -1,13 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import { JourneyFactory } from './journey.factory';
 import { InjectionToken, Injectable, Inject } from '@angular/core';
+import { ParticipantSuitabilityModel } from '../participant-suitability.model';
 
 export const JOURNEY_FACTORY = new InjectionToken<JourneyFactory>('JourneyFactory');
 
 @Injectable()
 export class JourneySelector {
+    private currentFactory: JourneyFactory;
+    private currentJourney: JourneyBase;
+
     constructor(@Inject(JOURNEY_FACTORY) private factories: JourneyFactory[]) {}
 
-    beginFor(userType: string): Promise<void> {
+    async beginFor(userType: string): Promise<void> {
         const factory = this.factories.filter(j => j.handles(userType));
         if (factory.length === 0) {
             throw new Error(`Found no journeys matching user type: ${userType}`);
@@ -15,6 +20,15 @@ export class JourneySelector {
             throw new Error(`Found more than one journey matching user type: ${userType}`);
         }
 
-        return factory[0].begin();
+        this.currentFactory = factory[0];
+        this.currentJourney = await this.currentFactory.begin();
+    }
+
+    getJourney(): JourneyBase {
+        return this.currentJourney;
+    }
+
+    getModel(): ParticipantSuitabilityModel {
+        return this.currentFactory.getModel();
     }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.selector.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/services/journey.selector.ts
@@ -25,10 +25,16 @@ export class JourneySelector {
     }
 
     getJourney(): JourneyBase {
+        if (!this.currentJourney) {
+            throw new Error('Journey has not been started yet');
+        }
         return this.currentJourney;
     }
 
     getModel(): ParticipantSuitabilityModel {
+        if (!this.currentFactory) {
+            throw new Error('Journey has not been started yet');
+        }
         return this.currentFactory.getModel();
     }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.factory.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.factory.spec.ts
@@ -36,4 +36,8 @@ describe('IndividualJourneyFactory', () => {
     it('handles individual users', () => {
         expect(factory.handles('Individual')).toBeTruthy();
     });
+
+    it('returns the journey model', () => {
+      expect(factory.getModel()).toBe(journey.model);
+    });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.factory.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.factory.ts
@@ -1,3 +1,4 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import { SuitabilityService } from './services/suitability.service';
 import { JourneyFactory } from 'src/app/modules/base-journey/services/journey.factory';
 import { IndividualJourney } from './individual-journey';
@@ -6,6 +7,7 @@ import { JourneyRoutingListenerService } from '../base-journey/services/journey-
 import { JourneyStepComponentBindings } from './services/journey-component-bindings';
 import {IndividualJourneyService} from './services/individual-journey.service';
 import {IndividualSuitabilityModel} from './individual-suitability.model';
+import { ParticipantSuitabilityModel } from '../base-journey/participant-suitability.model';
 
 const IndividualUserType = 'Individual';
 
@@ -24,7 +26,7 @@ export class IndividualJourneyFactory implements JourneyFactory {
             this.bindings = bindings;
     }
 
-    async begin(): Promise<void> {
+    async begin(): Promise<JourneyBase> {
       this.journey.redirect.subscribe(() =>
       this.individualJourneyService.set(this.journey.model));
 
@@ -39,10 +41,14 @@ export class IndividualJourneyFactory implements JourneyFactory {
 
       this.journey.forSuitabilityAnswers(models);
       this.journeyRoutingListenerService.initialise(this.bindings, this.journey);
-      return Promise.resolve();
+      return Promise.resolve(this.journey);
     }
 
     handles(userType: string): boolean {
         return userType === IndividualUserType;
+    }
+
+    getModel(): ParticipantSuitabilityModel {
+      return this.journey.model;
     }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.factory.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.factory.spec.ts
@@ -37,4 +37,8 @@ describe('RepresentativeJourneyFactory', () => {
   it('handles representative users', () => {
     expect(factory.handles('Representative')).toBeTruthy();
   });
+
+  it('returns the journey model', () => {
+    expect(factory.getModel()).toBe(journey.model);
+  });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.factory.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.factory.ts
@@ -1,3 +1,4 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {RepresentativeSuitabilityService} from './services/representative-suitability.service';
 import {JourneyFactory} from 'src/app/modules/base-journey/services/journey.factory';
 import {RepresentativeJourney} from './representative-journey';
@@ -6,6 +7,7 @@ import {JourneyRoutingListenerService} from '../base-journey/services/journey-ro
 import {RepresentativeJourneyStepComponentBindings} from './services/representative-journey-component-bindings';
 import {RepresentativeSuitabilityModel} from './representative-suitability.model';
 import {RepresentativeJourneyService} from './services/representative.journey.service';
+import { ParticipantSuitabilityModel } from '../base-journey/participant-suitability.model';
 
 const RepresentativeUserType = 'Representative';
 
@@ -23,7 +25,7 @@ export class RepresentativeJourneyFactory implements JourneyFactory {
     this.bindings = bindings;
   }
 
-  async begin(): Promise<void> {
+  async begin(): Promise<JourneyBase> {
     this.journey.redirect.subscribe(() =>
       this.representativeJourneyService.set(this.journey.model));
 
@@ -38,10 +40,14 @@ export class RepresentativeJourneyFactory implements JourneyFactory {
 
     this.journey.forSuitabilityAnswers(models);
     this.journeyRoutingListenerService.initialise(this.bindings, this.journey);
-    return Promise.resolve();
+    return Promise.resolve(this.journey);
   }
 
   handles(userType: string): boolean {
     return userType === RepresentativeUserType;
+  }
+
+  getModel(): ParticipantSuitabilityModel {
+    return this.journey.model;
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/camera-working/camera-working.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/camera-working/camera-working.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {CameraWorkingComponent} from './camera-working.component';
 
 describe('CameraWorkingComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: CameraWorkingComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/microphone-working/microphone-working.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/microphone-working/microphone-working.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {MicrophoneWorkingComponent} from './microphone-working.component';
 
 describe('MicrophoneWorkingComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: MicrophoneWorkingComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/same-computer/same-computer.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/same-computer/same-computer.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {SameComputerComponent} from './same-computer.component';
 
 describe('SameComputerComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: SameComputerComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/see-and-hear-video/see-and-hear-video.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/see-and-hear-video/see-and-hear-video.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {SeeAndHearVideoComponent} from './see-and-hear-video.component';
 
 describe('SeeAndHearVideoComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: SeeAndHearVideoComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test-base-component/self-test-base.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test-base-component/self-test-base.component.ts
@@ -1,10 +1,10 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {OnInit, Injectable} from '@angular/core';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ParticipantSuitabilityModel} from '../../../base-journey/participant-suitability.model';
 
 @Injectable()
 export abstract class SelfTestBaseComponent implements OnInit {
-  constructor(private journey: SelfTestJourney) {
+  constructor(private journey: JourneyBase, private suitabilityModel: ParticipantSuitabilityModel) {
   }
 
   ngOnInit(): void {
@@ -19,6 +19,6 @@ export abstract class SelfTestBaseComponent implements OnInit {
   }
 
   get model(): ParticipantSuitabilityModel {
-    return this.journey.model;
+    return this.suitabilityModel;
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test-base-component/self-test-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test-base-component/self-test-component-test-bed.spec.ts
@@ -1,3 +1,4 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneySteps} from '../../self-test-journey-steps';
 import {ComponentFixture} from '@angular/core/testing';
 import {SelfTestJourney} from '../../self-test-journey';
@@ -8,9 +9,11 @@ import {
   ComponentTestBedConfiguration
 } from 'src/app/modules/base-journey/components/journey-component-test-bed.spec';
 import {ContinuableComponentFixture} from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
+import { ParticipantSuitabilityModel, SelfTestAnswers } from 'src/app/modules/base-journey/participant-suitability.model';
 
 export interface SelfTestComponentTestBedConfiguration<TComponent> extends ComponentTestBedConfiguration<TComponent> {
-  journey?: SelfTestJourney;
+  journey?: JourneyBase;
+  model?: ParticipantSuitabilityModel;
 }
 
 export class CommonSelfTestComponentTests {
@@ -35,7 +38,8 @@ export class SelfTestJourneyStubs {
     const deviceType = jasmine.createSpyObj<DeviceType>(['isMobile']);
     const stepsOrderFactory = new SelfTestStepsOrderFactory(deviceType);
     deviceType.isMobile.and.returnValue(false);
-    const journey = new SelfTestJourney(stepsOrderFactory);
+    const model = { selfTest: new SelfTestAnswers() } as ParticipantSuitabilityModel;
+    const journey = new SelfTestJourney(model, stepsOrderFactory);
     journey.startAt(SelfTestJourneySteps.UseCameraAndMicrophoneAgain);
     return journey;
   }
@@ -43,6 +47,7 @@ export class SelfTestJourneyStubs {
 
 export class SelfTestJourneyComponentTestBed {
   static createComponent<TComponent>(config: SelfTestComponentTestBedConfiguration<TComponent>): ComponentFixture<TComponent> {
+    const defaultJourney = SelfTestJourneyStubs.default;
     return new JourneyComponentTestBed()
       .createComponent({
         component: config.component,
@@ -50,7 +55,8 @@ export class SelfTestJourneyComponentTestBed {
           ...(config.declarations || [])
         ],
         providers: [
-          {provide: SelfTestJourney, useValue: config.journey || SelfTestJourneyStubs.default},
+          { provide: JourneyBase, useValue: config.journey || defaultJourney },
+          { provide: ParticipantSuitabilityModel, useValue: config.model || defaultJourney.model },
           ...(config.providers || [])
         ],
         imports: config.imports

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test/self-test.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/self-test/self-test.component.spec.ts
@@ -1,16 +1,16 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {CrestBluePanelComponent} from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {SelfTestComponent} from './self-test.component';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 
 describe('SelfTestComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: SelfTestComponent,
-      declarations: [ CrestBluePanelComponent ],
-      providers: [ { provide: SelfTestJourney, useValue: journey } ]
+      journey: journey,
+      declarations: [ CrestBluePanelComponent ]
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/sign-in-other-computer/sign-in-other-computer.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/sign-in-other-computer/sign-in-other-computer.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {SignInOtherComputerComponent} from './sign-in-other-computer.component';
 
 describe('SignInOtherComputerComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: SignInOtherComputerComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/use-camera-microphone-again/use-camera-microphone-again.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/use-camera-microphone-again/use-camera-microphone-again.component.spec.ts
@@ -1,18 +1,18 @@
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import {SelfTestJourneyComponentTestBed} from '../self-test-base-component/self-test-component-test-bed.spec';
 import {
   CrestBluePanelComponent
 } from '../../../shared/crest-blue-panel/crest-blue-panel.component';
-import {SelfTestJourney} from '../../self-test-journey';
 import {ContinuableComponentFixture} from '../../../base-journey/components/suitability-choice-component-fixture.spec';
 import {UseCameraMicrophoneAgainComponent} from './use-camera-microphone-again.component';
 
 describe('UseCameraMicrophoneAgainComponent', () => {
   it('can continue', () => {
-    const journey = jasmine.createSpyObj<SelfTestJourney>(['next']);
+    const journey = jasmine.createSpyObj<JourneyBase>(['next']);
     const fixture = SelfTestJourneyComponentTestBed.createComponent({
       component: UseCameraMicrophoneAgainComponent,
       declarations: [CrestBluePanelComponent],
-      providers: [{provide: SelfTestJourney, useValue: journey}]
+      journey: journey
     });
 
     fixture.detectChanges();

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/self-test-journey.module.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/self-test-journey.module.ts
@@ -28,7 +28,7 @@ import {SelfTestJourney} from './self-test-journey';
     SelfTestJourney,
     SelfTestJourneyStepComponentBindings,
     JourneyRoutingListenerService,
-    SelfTestStepsOrderFactory,
+    SelfTestStepsOrderFactory
   ]
 })
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/self-test-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/self-test-journey.ts
@@ -1,12 +1,11 @@
 import {EventEmitter, Injectable} from '@angular/core';
-import {JourneyBase} from '../base-journey/journey-base';
 import {SelfTestStepsOrderFactory} from './self-test-steps-order.factory';
 import {SelfTestJourneySteps} from './self-test-journey-steps';
 import {JourneyStep} from '../base-journey/journey-step';
 import {ParticipantSuitabilityModel} from '../base-journey/participant-suitability.model';
 
 @Injectable()
-export class SelfTestJourney extends JourneyBase {
+export class SelfTestJourney {
   static readonly initialStep = SelfTestJourneySteps.SameComputer;
   readonly redirect: EventEmitter<JourneyStep> = new EventEmitter();
   stepOrder: Array<JourneyStep>;
@@ -15,12 +14,12 @@ export class SelfTestJourney extends JourneyBase {
   private isDone: boolean;
   private isSubmitted: boolean;
 
-  constructor(private individualStepsOrderFactory: SelfTestStepsOrderFactory) {
-    super();
+  constructor(participantModel: ParticipantSuitabilityModel, private stepsFactory: SelfTestStepsOrderFactory) {
     this.redirect.subscribe((step: JourneyStep) => {
       this.currentStep = step;
     });
-    this.stepOrder = this.individualStepsOrderFactory.stepOrder();
+    this.stepOrder = this.stepsFactory.stepOrder();
+    this.currentModel = participantModel;
   }
 
   get step(): SelfTestJourneySteps {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4577

### Change description ###
I've changed the self-test components to take a base journey and model instead of the self-test journey. This will allow them to dynamically act on the `IndividualJourney` or `RepresentativeJourney` depending on which one is active.

This works by reutilising the journey selector, which is responsible for determining the current journey.

The self-test pages are still accessible straight from URL but when we press next, as we can see in the error log, it complains that the journey hasn't been initialised. This would change as soon as we enter the steps into Individual/Representative journey respectively.

![image](https://user-images.githubusercontent.com/8461739/60577811-ffcffa80-9d77-11e9-80b4-e39cdec7c7e1.png)

The existing journey still works.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
