### PR TITLE
Refactor move dropoff code

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -87,7 +87,7 @@ export class RepresentativeJourney extends JourneyBase {
 
     let nextStep = this.stepOrder[currentStep + 1];
 
-    if (this.submitService.isDropOffPoint(this.model) && !this.isSubmitted) {
+    if (this.isDropOffPoint() && !this.isSubmitted) {
       // update the model to set the answers in case browserback was clicked and the answers were changed.
       this.submitService.submit(this.model);
       this.isSubmitted = true;
@@ -101,6 +101,11 @@ export class RepresentativeJourney extends JourneyBase {
     }
 
     this.goto(nextStep);
+  }
+
+  isDropOffPoint(): boolean {
+    return (this.model.computer === false || this.model.camera === HasAccessToCamera.No ||
+      this.model.camera === HasAccessToCamera.Yes || this.model.camera === HasAccessToCamera.NotSure);
   }
 
   fail() {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -6,7 +6,6 @@ import { RepresentativeJourneySteps } from './representative-journey-steps';
 import { HasAccessToCamera } from '../base-journey/participant-suitability.model';
 import { JourneyStep } from '../base-journey/journey-step';
 import { SubmitService } from './services/submit.service';
-import { MutableRepresentativeSuitabilityModel } from './mutable-representative-suitability.model';
 
 @Injectable()
 export class RepresentativeJourney extends JourneyBase {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.spec.ts
@@ -28,28 +28,28 @@ describe('SubmitService', () => {
     expect(suitabilityService.updateSuitabilityAnswers).toHaveBeenCalled();
   });
 
-  it('should return true when at a drop off step - access to computer', () => {
-    model.computer = false;
-    const result = submitService.isDropOffPoint(model);
-    expect(result).toBe(true);
-  });
-  it('should return true when at a drop off step - access to camera', () => {
-    model.computer = true;
-    model.camera = HasAccessToCamera.No;
-    const result = submitService.isDropOffPoint(model);
-    expect(result).toBe(true);
-  });
-  it('should return true when at a stpe- access to camera - is - yes', () => {
-    model.computer = true;
-    model.camera = HasAccessToCamera.Yes;
-    const result = submitService.isDropOffPoint(model);
-    expect(result).toBe(true);
-  });
+  // it('should return true when at a drop off step - access to computer', () => {
+  //   model.computer = false;
+  //   const result = submitService.isDropOffPoint(model);
+  //   expect(result).toBe(true);
+  // });
+  // it('should return true when at a drop off step - access to camera', () => {
+  //   model.computer = true;
+  //   model.camera = HasAccessToCamera.No;
+  //   const result = submitService.isDropOffPoint(model);
+  //   expect(result).toBe(true);
+  // });
+  // it('should return true when at a stpe- access to camera - is - yes', () => {
+  //   model.computer = true;
+  //   model.camera = HasAccessToCamera.Yes;
+  //   const result = submitService.isDropOffPoint(model);
+  //   expect(result).toBe(true);
+  // });
 
-  it('should return true when at a stpe- access to camera - is - Not Sure', () => {
-    model.computer = true;
-    model.camera = HasAccessToCamera.NotSure;
-    const result = submitService.isDropOffPoint(model);
-    expect(result).toBe(true);
-  });
+  // it('should return true when at a stpe- access to camera - is - Not Sure', () => {
+  //   model.computer = true;
+  //   model.camera = HasAccessToCamera.NotSure;
+  //   const result = submitService.isDropOffPoint(model);
+  //   expect(result).toBe(true);
+  // });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.spec.ts
@@ -2,7 +2,6 @@ import { SubmitService } from './submit.service';
 import { MutableRepresentativeSuitabilityModel } from '../mutable-representative-suitability.model';
 import { Hearing, HasAccessToCamera } from '../../base-journey/participant-suitability.model';
 import { RepresentativeSuitabilityService } from './representative-suitability.service';
-import { RepresentativeJourneySteps } from '../representative-journey-steps';
 
 describe('SubmitService', () => {
   const suitabilityService = jasmine.createSpyObj<RepresentativeSuitabilityService>(['updateSuitabilityAnswers']);
@@ -27,29 +26,4 @@ describe('SubmitService', () => {
     await submitService.submit(model);
     expect(suitabilityService.updateSuitabilityAnswers).toHaveBeenCalled();
   });
-
-  // it('should return true when at a drop off step - access to computer', () => {
-  //   model.computer = false;
-  //   const result = submitService.isDropOffPoint(model);
-  //   expect(result).toBe(true);
-  // });
-  // it('should return true when at a drop off step - access to camera', () => {
-  //   model.computer = true;
-  //   model.camera = HasAccessToCamera.No;
-  //   const result = submitService.isDropOffPoint(model);
-  //   expect(result).toBe(true);
-  // });
-  // it('should return true when at a stpe- access to camera - is - yes', () => {
-  //   model.computer = true;
-  //   model.camera = HasAccessToCamera.Yes;
-  //   const result = submitService.isDropOffPoint(model);
-  //   expect(result).toBe(true);
-  // });
-
-  // it('should return true when at a stpe- access to camera - is - Not Sure', () => {
-  //   model.computer = true;
-  //   model.camera = HasAccessToCamera.NotSure;
-  //   const result = submitService.isDropOffPoint(model);
-  //   expect(result).toBe(true);
-  // });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.ts
@@ -18,10 +18,10 @@ export class SubmitService {
     await this.suitabilityService.updateSuitabilityAnswers(model.hearing.id, answers);
   }
 
-  isDropOffPoint(model: RepresentativeSuitabilityModel): boolean {
+  // isDropOffPoint(model: RepresentativeSuitabilityModel): boolean {
 
-    return (model.computer === false || model.camera === HasAccessToCamera.No ||
-      model.camera === HasAccessToCamera.Yes || model.camera === HasAccessToCamera.NotSure);
+  //   return (model.computer === false || model.camera === HasAccessToCamera.No ||
+  //     model.camera === HasAccessToCamera.Yes || model.camera === HasAccessToCamera.NotSure);
 
-  }
+  // }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/services/submit.service.ts
@@ -2,11 +2,7 @@ import { Injectable } from '@angular/core';
 import { HearingSuitabilityAnswer } from 'src/app/services/clients/api-client';
 import { RepresentativeModelMapper } from './representative-model-mapper';
 import { RepresentativeSuitabilityService } from './representative-suitability.service';
-import { SuitabilityAnswer, HasAccessToCamera } from '../../base-journey/participant-suitability.model';
 import { RepresentativeSuitabilityModel } from '../representative-suitability.model';
-import { MutableRepresentativeSuitabilityModel } from '../mutable-representative-suitability.model';
-import { JourneyStep } from '../../base-journey/journey-step';
-import { RepresentativeJourneySteps } from '../representative-journey-steps';
 
 @Injectable()
 export class SubmitService {
@@ -17,11 +13,4 @@ export class SubmitService {
     const answers: HearingSuitabilityAnswer[] = new RepresentativeModelMapper().mapToRequest(model);
     await this.suitabilityService.updateSuitabilityAnswers(model.hearing.id, answers);
   }
-
-  // isDropOffPoint(model: RepresentativeSuitabilityModel): boolean {
-
-  //   return (model.computer === false || model.camera === HasAccessToCamera.No ||
-  //     model.camera === HasAccessToCamera.Yes || model.camera === HasAccessToCamera.NotSure);
-
-  // }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a

### Change description ###
I noticed that by checking the drop off conditions and testing them separately from the journey, we were risking messing up the code as the `isDropOffPoint` was being mocked. Since this is really to do with the actual journey I moved it into the journey and moved the tests for it into the journey as well.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
