### PR TITLE
Refactor simplifying journey

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/suitability-choice-page-base.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/components/suitability-choice-page-base.component.ts
@@ -24,15 +24,21 @@ export abstract class SuitabilityChoicePageBaseComponent<TJourneyType extends Jo
     return this.form.invalid && this.submitted;
   }
 
-  continue() {
+  trySubmit(): boolean {
     this.submitted = true;
 
     if (this.form.invalid) {
-      return;
+      return false;
     }
 
     this.bindModel();
-    this.onFormAccepted();
+    return true;
+  }
+
+  continue() {
+    if (this.trySubmit()) {
+      this.onFormAccepted();
+    }
   }
 
   /**

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view-base/video-view-base.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view-base/video-view-base.component.spec.ts
@@ -1,15 +1,13 @@
 import { VideoUrlService } from '../../services/video-url.service';
 import { VideoViewBaseComponent } from './video-view-base.component';
 import { VideoFiles } from '../../services/video-files';
-import { IndividualJourneyStubs } from '../../pages/individual-base-component/individual-component-test-bed.spec';
 
 describe('functionality', () => {
   let component: VideoViewBaseComponent;
   const videoUrlService = jasmine.createSpyObj<VideoUrlService>(['getVideoFileUrl']);
 
   beforeEach(() => {
-    const journey = IndividualJourneyStubs.default;
-    component = new VideoViewBaseComponent(journey, videoUrlService, VideoFiles.BeforeTheDay_Court);
+    component = new VideoViewBaseComponent(videoUrlService, VideoFiles.BeforeTheDay_Court);
   });
 
   it('should set the video source when initialized', () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view-base/video-view-base.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view-base/video-view-base.component.ts
@@ -6,11 +6,10 @@ import { VideoUrlService } from '../../services/video-url.service';
 import { VideoFiles } from '../../services/video-files';
 
 @Injectable()
-export class VideoViewBaseComponent extends IndividualBaseComponent implements OnInit {
+export class VideoViewBaseComponent implements OnInit {
 
-  constructor(journey: IndividualJourney, private videoUrlService: VideoUrlService,
+  constructor(private videoUrlService: VideoUrlService,
     private videoFile: VideoFiles) {
-    super(journey);
   }
 
   @ViewChild(VideoViewComponent)

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
@@ -83,7 +83,6 @@ export class IndividualJourney extends JourneyBase {
     }
 
     if (this.submitService.isDropOffPoint(this.model)) {
-      // update the model to set the answers in case browserback was clicked and the answers were changed.
       let saveModel: MutableIndividualSuitabilityModel;
       saveModel = this.submitService.updateSubmitModel(this.currentStep, this.model);
       // save the updated model.
@@ -127,6 +126,14 @@ export class IndividualJourney extends JourneyBase {
     } else {
       this.currentStep = position;
     }
+  }
+
+  async submitQuestionnaire(): Promise<void> {
+    let saveModel: MutableIndividualSuitabilityModel;
+    saveModel = this.submitService.updateSubmitModel(this.currentStep, this.model);
+    // save the updated model.
+    await this.submitService.submit(saveModel);
+    this.isSubmitted = true;
   }
 
   /**

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/individual-journey.ts
@@ -55,7 +55,7 @@ export class IndividualJourney extends JourneyBase {
     return this.currentModel;
   }
 
-  private goto(step: JourneyStep) {
+  goto(step: JourneyStep) {
     if (this.currentStep !== step) {
       this.redirect.emit(step);
     }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.spec.ts
@@ -7,7 +7,7 @@ import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('AboutHearingsComponent', () => {
   it(`should continue to ${IndividualJourneySteps.DifferentHearingTypes}`, () => {
-    const journey = jasmine.createSpyObj<IndividualJourney>(['jumpTo']);
+    const journey = jasmine.createSpyObj<IndividualJourney>(['goto']);
     const fixture = IndividualJourneyComponentTestBed.createComponent({
       component: AboutHearingsComponent,
       declarations: [ CrestBluePanelComponent ],
@@ -16,6 +16,6 @@ describe('AboutHearingsComponent', () => {
 
     fixture.detectChanges();
     new ContinuableComponentFixture(fixture).submitIsClicked();
-    expect(journey.jumpTo).toHaveBeenCalledWith(IndividualJourneySteps.DifferentHearingTypes);
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.DifferentHearingTypes);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.spec.ts
@@ -3,10 +3,11 @@ import { CrestBluePanelComponent } from 'src/app/modules/shared/crest-blue-panel
 import { AboutHearingsComponent } from './about-hearings.component';
 import { IndividualJourney } from '../../individual-journey';
 import { ContinuableComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('AboutHearingsComponent', () => {
-  it('can continue', () => {
-    const journey = jasmine.createSpyObj<IndividualJourney>(['next']);
+  it(`should continue to ${IndividualJourneySteps.DifferentHearingTypes}`, () => {
+    const journey = jasmine.createSpyObj<IndividualJourney>(['jumpTo']);
     const fixture = IndividualJourneyComponentTestBed.createComponent({
       component: AboutHearingsComponent,
       declarations: [ CrestBluePanelComponent ],
@@ -15,6 +16,6 @@ describe('AboutHearingsComponent', () => {
 
     fixture.detectChanges();
     new ContinuableComponentFixture(fixture).submitIsClicked();
-    expect(journey.next).toHaveBeenCalled();
+    expect(journey.jumpTo).toHaveBeenCalledWith(IndividualJourneySteps.DifferentHearingTypes);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
@@ -1,10 +1,15 @@
 import { Component } from '@angular/core';
-import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
+import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-about-hearings',
-  templateUrl: './about-hearings.component.html',
-  styles: []
+  templateUrl: './about-hearings.component.html'
 })
-export class AboutHearingsComponent extends IndividualBaseComponent {
+export class AboutHearingsComponent {
+  constructor(private journey: IndividualJourney) {}
+
+  continue() {
+    this.journey.jumpTo(IndividualJourneySteps.DifferentHearingTypes);
+  }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
@@ -4,7 +4,8 @@ import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-about-hearings',
-  templateUrl: './about-hearings.component.html'
+  templateUrl: './about-hearings.component.html',
+  styles: []
 })
 export class AboutHearingsComponent {
   constructor(private journey: IndividualJourney) {}

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-hearings/about-hearings.component.ts
@@ -10,6 +10,6 @@ export class AboutHearingsComponent {
   constructor(private journey: IndividualJourney) {}
 
   continue() {
-    this.journey.jumpTo(IndividualJourneySteps.DifferentHearingTypes);
+    this.journey.goto(IndividualJourneySteps.DifferentHearingTypes);
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.html
@@ -4,7 +4,7 @@
       About you
     </h1>
 
-    <app-choice-textbox [suitabilityAnswer]="journey.model.aboutYou" (submitted)="journey.next()">
+    <app-choice-textbox [suitabilityAnswer]="journey.model.aboutYou" (submitted)="submit()">
       <p class="govuk-body govuk-!-margin-bottom-6" i18n="@@aboutYou_p_1">
         Is there anything you’d like the court to take into account when it decides which type of hearing will be
         suitable?

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.spec.ts
@@ -3,6 +3,7 @@ import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../in
 import { SuitabilityChoiceComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
 import { AboutYouComponent } from './about-you.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('AboutYouComponent', () => {
   let fixture: SuitabilityChoiceComponentFixture;
@@ -23,10 +24,10 @@ describe('AboutYouComponent', () => {
     fixture.detectChanges();
   });
 
-  it('binds values and goes to next step after selecting choice and choosing continue', () => {
+  it('binds values and goes to interpreter after selecting choice and choosing continue', () => {
     fixture.radioBoxIsClicked('#choice-no');
     fixture.submitIsClicked();
     expect(journey.model.aboutYou.answer).toBe(false);
-    expect(journey.next).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.Interpreter);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-you/about-you.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-about-you',
@@ -11,5 +12,9 @@ export class AboutYouComponent {
 
   constructor(journey: IndividualJourney) {
     this.journey = journey;
+  }
+
+  submit() {
+    this.journey.goto(IndividualJourneySteps.Interpreter);
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.html
@@ -5,7 +5,7 @@
     </h1>
 
 
-    <form [formGroup]="form" (ngSubmit)="continue()">
+    <form [formGroup]="form" (ngSubmit)="submit()">
 
       <div id="form-container" [ngClass]="isFormInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
         <div class="govuk-fieldset">
@@ -60,7 +60,7 @@
       </div>
 
       <div class="vh-top-20">
-        <button class="govuk-button" (click)="continue()" i18n="@@aboutYourComputer_journey_btn_continue" id="continue"
+        <button class="govuk-button" (click)="submit()" i18n="@@aboutYourComputer_journey_btn_continue" id="continue"
                 type="button">
           Continue
         </button>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.spec.ts
@@ -1,18 +1,34 @@
+import { HasAccessToCamera } from './../../../base-journey/participant-suitability.model';
+import { IndividualJourneyStubs } from './../individual-base-component/individual-component-test-bed.spec';
 import { AboutYourComputerComponent } from './about-your-computer.component';
 import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
 import {
   SuitabilityChoiceComponentFixture,
   ChoicePageTests
 } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('AboutYourComputerComponent', () => {
-  it('cannot proceed to next step until pressing choice, after submit value is bound', () => {
-    const fixture = IndividualJourneyComponentTestBed.createComponent({component: AboutYourComputerComponent});
+  it(`cannot proceed to next step until pressing choice, then goes to ${IndividualJourneySteps.YourInternetConnection}`, () => {
+    const journey = IndividualJourneyStubs.journeySpy;
+    const fixture = IndividualJourneyComponentTestBed.createComponent({
+      component: AboutYourComputerComponent,
+      journey: journey
+    });
     const choiceComponentFixture = new SuitabilityChoiceComponentFixture(fixture);
     const choicePageTests = new ChoicePageTests(choiceComponentFixture, fixture.componentInstance);
     choicePageTests.cannotProceedUntilChoiceIsSelected();
 
-    // and value is bound
     expect(fixture.componentInstance.model.camera).toBe(0);
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.YourInternetConnection);
+  });
+
+  it(`should submit and go to ${IndividualJourneySteps.ThankYou} if answering no`, async () => {
+    const journey = IndividualJourneyStubs.journeySpy;
+    const component = new AboutYourComputerComponent(journey);
+    component.choice.setValue(HasAccessToCamera.No);
+    await component.submit();
+    expect(journey.submitQuestionnaire).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ThankYou);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/about-your-computer/about-your-computer.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { HasAccessToCamera } from '../../../base-journey/participant-suitability.model';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-about-your-computer',
@@ -22,5 +23,18 @@ export class AboutYourComputerComponent extends SuitabilityChoicePageBaseCompone
 
   protected bindModel(): void {
     this.model.camera = this.choice.value;
+  }
+
+  async submit(): Promise<void> {
+    if (!this.trySubmit()) {
+      return;
+    }
+
+    if (this.model.camera === HasAccessToCamera.No) {
+      this.journey.submitQuestionnaire();
+      this.journey.goto(IndividualJourneySteps.ThankYou);
+    } else {
+      this.journey.goto(IndividualJourneySteps.YourInternetConnection);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.html
@@ -4,7 +4,7 @@
       A quiet, private room
     </h1>
 
-    <form [formGroup]="form" (ngSubmit)="continue()">
+    <form [formGroup]="form" (ngSubmit)="submit()">
 
       <div id="form-container" [ngClass]="isFormInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
         <div class="govuk-fieldset">
@@ -63,7 +63,7 @@
       </div>
 
       <div class="mt-20">
-        <button class="govuk-button" (click)="continue()" i18n="@@accessRoom_btn_continue" id="continue"
+        <button class="govuk-button" (click)="submit()" i18n="@@accessRoom_btn_continue" id="continue"
                 type="button">
           Continue
         </button>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.spec.ts
@@ -1,20 +1,28 @@
 import { AccessToRoomComponent } from './access-to-room.component';
-import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../individual-base-component/individual-component-test-bed.spec';
 import { ComponentFixture } from '@angular/core/testing';
 import { CommonTests } from 'src/app/modules/base-journey/components/common-tests.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
+import { IndividualJourney } from '../../individual-journey';
 
 describe('AccessToRoomComponent', () => {
   let fixture: ComponentFixture<AccessToRoomComponent>;
+  let journey: IndividualJourney;
 
   beforeEach(() => {
-    fixture = IndividualJourneyComponentTestBed.createComponent({component: AccessToRoomComponent});
+    journey = IndividualJourneyStubs.journeySpy;
+    fixture = IndividualJourneyComponentTestBed.createComponent({
+      component: AccessToRoomComponent,
+      journey: journey
+    });
   });
 
-  it('cannot proceed to next step until pressing choice, after submit value is bound', () => {
+  it(`cannot proceed to next step until pressing choice, then goes to ${IndividualJourneySteps.Consent}`, () => {
     CommonTests.cannotProceedUntilChoiceIsSelected(fixture);
 
     // and value is bound
     expect(fixture.componentInstance.model.room).toBe(true);
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.Consent);
   });
 
   it('should contain the scheduled date on init', () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/access-to-room/access-to-room.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-access-to-room',
@@ -22,5 +23,11 @@ export class AccessToRoomComponent extends SuitabilityChoicePageBaseComponent im
 
   protected bindModel() {
     this.model.room = this.choice.value;
+  }
+
+  submit() {
+    if (this.trySubmit()) {
+      this.journey.goto(IndividualJourneySteps.Consent);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.html
@@ -5,7 +5,7 @@
       Your consent for a video hearing
     </h1>
 
-    <form [formGroup]="form" (ngSubmit)="continue()">
+    <form [formGroup]="form" (ngSubmit)="submit()">
 
       <div id="form-container" [ngClass]="isFormInvalid && !textInputNo.invalid ? 'govuk-form-group--error' : 'govuk-form-group'">
         <div class="govuk-fieldset">
@@ -85,7 +85,7 @@
       </div>
 
       <div class="mt-20">
-        <button class="govuk-button" (click)="continue()" i18n="@@consent_btn_continue" id="continue"
+        <button class="govuk-button" (click)="submit()" i18n="@@consent_btn_continue" id="continue"
                 type="button">
           Continue
         </button>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.spec.ts
@@ -1,13 +1,22 @@
+import { IndividualJourneyStubs } from './../individual-base-component/individual-component-test-bed.spec';
+import { JourneyBase } from 'src/app/modules/base-journey/journey-base';
 import { SuitabilityChoiceComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
 import { ConsentComponent } from './consent.component';
 import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
+import { IndividualJourney } from '../../individual-journey';
 
 describe('ConsentComponent', () => {
   let fixture: SuitabilityChoiceComponentFixture;
   let component: ConsentComponent;
+  let journey: jasmine.SpyObj<IndividualJourney>;
 
   beforeEach(() => {
-    const componentFixture = IndividualJourneyComponentTestBed.createComponent({component: ConsentComponent});
+    journey = IndividualJourneyStubs.journeySpy;
+    const componentFixture = IndividualJourneyComponentTestBed.createComponent({
+      component: ConsentComponent,
+      journey: journey
+    });
     fixture = new SuitabilityChoiceComponentFixture(componentFixture);
     component = componentFixture.componentInstance;
     fixture.detectChanges();
@@ -107,6 +116,17 @@ describe('ConsentComponent', () => {
 
      // then
     expect(component.textInputYes.value).toBe('notes');
+  });
+
+  it(`should submit questionnaire and go to ${IndividualJourneySteps.ThankYou} on submitting`, async () => {
+    component.ngOnInit();
+    component.choice.setValue(true);
+    component.textInputYes.setValue('comments');
+
+    await component.submit();
+
+    expect(journey.submitQuestionnaire).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ThankYou);
   });
 });
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.ts
@@ -77,17 +77,13 @@ export class ConsentComponent extends SuitabilityChoicePageBaseComponent impleme
     return this.textInputNo.invalid && this.submitted;
   }
 
-  continue() {
-    this.textInputYes.markAsTouched();
-    super.continue();
-  }
-
   protected bindModel(): void {
     this.model.consent.answer = this.choice.value;
     this.model.consent.notes = this.choice.value ? this.textInputYes.value : this.textInputNo.value;
   }
 
   async submit(): Promise<void> {
+    this.textInputYes.markAsTouched();
     if (this.trySubmit()) {
       await this.journey.submitQuestionnaire();
       this.journey.goto(IndividualJourneySteps.ThankYou);

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/consent/consent.component.ts
@@ -3,6 +3,7 @@ import { FormControl, Validators } from '@angular/forms';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { ValidateForWhiteSpace } from '../../../shared/validators/whitespace-validator';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-consent',
@@ -84,5 +85,12 @@ export class ConsentComponent extends SuitabilityChoicePageBaseComponent impleme
   protected bindModel(): void {
     this.model.consent.answer = this.choice.value;
     this.model.consent.notes = this.choice.value ? this.textInputYes.value : this.textInputNo.value;
+  }
+
+  async submit(): Promise<void> {
+    if (this.trySubmit()) {
+      await this.journey.submitQuestionnaire();
+      this.journey.goto(IndividualJourneySteps.ThankYou);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/court-building-video/court-building-video.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/court-building-video/court-building-video.component.spec.ts
@@ -2,14 +2,15 @@ import { ContinuableComponentFixture } from './../../../base-journey/components/
 import { IndividualJourney } from './../../individual-journey';
 import { CourtBuildingVideoComponent } from './court-building-video.component';
 import { VideoViewComponentTestBed } from '../../components/video-view-base/video-view-component-test-bed.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('CourtBuildingVideoComponent', () => {
-  it('continues when pressing button', (() => {
-    const journey = jasmine.createSpyObj<IndividualJourney>(['next']);
+  it(`goes to ${IndividualJourneySteps.ExploreVideoHearing} when pressing continue`, (() => {
+    const journey = jasmine.createSpyObj<IndividualJourney>(['goto']);
     const fixture = VideoViewComponentTestBed.createComponent(CourtBuildingVideoComponent, journey);
 
     const test = new ContinuableComponentFixture(fixture);
     test.submitIsClicked();
-    expect(journey.next).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ExploreVideoHearing);
   }));
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/court-building-video/court-building-video.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/court-building-video/court-building-video.component.ts
@@ -3,6 +3,7 @@ import { VideoUrlService } from '../../services/video-url.service';
 import { VideoFiles } from '../../services/video-files';
 import { IndividualJourney } from '../../individual-journey';
 import { VideoViewBaseComponent } from '../../components/video-view-base/video-view-base.component';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-court-building-video',
@@ -11,7 +12,11 @@ import { VideoViewBaseComponent } from '../../components/video-view-base/video-v
 })
 export class CourtBuildingVideoComponent extends VideoViewBaseComponent {
 
-  constructor(journey: IndividualJourney, videoUrlService: VideoUrlService) {
-    super(journey, videoUrlService, VideoFiles.BeforeTheDay_Court);
+  constructor(private journey: IndividualJourney, videoUrlService: VideoUrlService) {
+    super(videoUrlService, VideoFiles.BeforeTheDay_Court);
+  }
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.ExploreVideoHearing);
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/different-hearing-types/different-hearing-types.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/different-hearing-types/different-hearing-types.component.spec.ts
@@ -3,10 +3,11 @@ import { IndividualJourneyComponentTestBed } from '../individual-base-component/
 import { DifferentHearingTypesComponent } from './different-hearing-types.component';
 import { IndividualJourney } from '../../individual-journey';
 import { ContinuableComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('DifferentHearingTypesComponent', () => {
-  it('can proceed', () => {
-    const journey = jasmine.createSpyObj<IndividualJourney>(['next']);
+  it(`continues to ${IndividualJourneySteps.ExploreCourtBuilding} on pressing continue`, () => {
+    const journey = jasmine.createSpyObj<IndividualJourney>(['goto']);
     const fixture = IndividualJourneyComponentTestBed.createComponent({
       component: DifferentHearingTypesComponent,
       declarations: [ CrestBluePanelComponent ],
@@ -15,6 +16,6 @@ describe('DifferentHearingTypesComponent', () => {
 
     fixture.detectChanges();
     new ContinuableComponentFixture(fixture).submitIsClicked();
-    expect(journey.next).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ExploreCourtBuilding);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/different-hearing-types/different-hearing-types.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/different-hearing-types/different-hearing-types.component.ts
@@ -1,10 +1,15 @@
 import { Component } from '@angular/core';
-import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
+import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-different-hearing-types',
-  templateUrl: './different-hearing-types.component.html',
-  styles: []
+  templateUrl: './different-hearing-types.component.html'
 })
-export class DifferentHearingTypesComponent extends IndividualBaseComponent {
+export class DifferentHearingTypesComponent {
+  constructor(private journey: IndividualJourney) {}
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.ExploreCourtBuilding);
+  }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-court-building/explore-court-building.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-court-building/explore-court-building.component.spec.ts
@@ -1,10 +1,12 @@
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { CommonIndividualComponentTests } from '../individual-base-component/individual-component-test-bed.spec';
 import { ExploreCourtBuildingComponent } from './explore-court-building.component';
 
 describe('ExploreCourtBuildingComponent', () => {
-  it('continues when button is pressed', () => {
-    CommonIndividualComponentTests.continuesWhenButtonIsPressed({
-      component: ExploreCourtBuildingComponent
-    });
+  it(`goes to ${IndividualJourneySteps.CourtInformationVideo} when pressing continue`, () => {
+    CommonIndividualComponentTests.goesToStepWhenButtonIsPressed(
+      IndividualJourneySteps.CourtInformationVideo,
+      { component: ExploreCourtBuildingComponent }
+    );
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-court-building/explore-court-building.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-court-building/explore-court-building.component.ts
@@ -1,10 +1,16 @@
 import { Component } from '@angular/core';
-import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
+import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-explore-court-building',
   templateUrl: './explore-court-building.component.html',
   styles: []
 })
-export class ExploreCourtBuildingComponent extends IndividualBaseComponent {
+export class ExploreCourtBuildingComponent {
+  constructor(private journey: IndividualJourney) {}
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.CourtInformationVideo);
+  }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-video-hearing/explore-video-hearing.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-video-hearing/explore-video-hearing.component.spec.ts
@@ -1,41 +1,38 @@
+import { ComponentFixture } from '@angular/core/testing';
 import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
 import { ExploreVideoHearingComponent } from './explore-video-hearing.component';
 import { DeviceType } from '../../../base-journey/services/device-type';
 import { ContinuableComponentFixture } from 'src/app/modules/base-journey/components/suitability-choice-component-fixture.spec';
 import { IndividualJourney } from '../../individual-journey';
-
-const deviceType = jasmine.createSpyObj<DeviceType>(['isMobile']);
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('ExploreVideoHearingComponent', () => {
   let journey: IndividualJourney;
+  let fixture: ComponentFixture<ExploreVideoHearingComponent>;
+  let deviceType: jasmine.SpyObj<DeviceType>;
 
   beforeEach(() => {
-    journey = jasmine.createSpyObj<IndividualJourney>(['next']);
-  });
+    journey = jasmine.createSpyObj<IndividualJourney>(['goto']);
+    deviceType = jasmine.createSpyObj<DeviceType>(['isMobile']);
 
-  it('can proceed on pressing continue', () => {
-    const fixture = IndividualJourneyComponentTestBed.createComponent({
+    fixture = IndividualJourneyComponentTestBed.createComponent({
       component: ExploreVideoHearingComponent,
       providers: [ { provide: DeviceType, useValue: deviceType }],
       journey: journey
     });
+  });
 
+  it(`goes straight to ${IndividualJourneySteps.HearingAsParticipant} on mobile`, () => {
+    deviceType.isMobile.and.returnValue(true);
     const test = new ContinuableComponentFixture(fixture);
     test.submitIsClicked();
-    expect(journey.next).toHaveBeenCalled();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.HearingAsParticipant);
   });
 
-  it('should detect device is mobile phone', () => {
-    deviceType.isMobile.and.returnValue(true);
-    const component = new ExploreVideoHearingComponent(journey, deviceType);
-
-    expect(component.isMobile).toBeTruthy();
-  });
-
-  it('should detect device is not mobile phone', () => {
+  it(`goes to ${IndividualJourneySteps.AccessToCameraAndMicrophone} on desktop`, () => {
     deviceType.isMobile.and.returnValue(false);
-    const component = new ExploreVideoHearingComponent(journey, deviceType);
-
-    expect(component.isMobile).toBeFalsy();
+    const test = new ContinuableComponentFixture(fixture);
+    test.submitIsClicked();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.AccessToCameraAndMicrophone);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-video-hearing/explore-video-hearing.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/explore-video-hearing/explore-video-hearing.component.ts
@@ -2,19 +2,25 @@ import { Component } from '@angular/core';
 import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
 import { DeviceType } from '../../../base-journey/services/device-type';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-explore-video-hearing',
-  templateUrl: './explore-video-hearing.component.html',
-  styles: []
+  templateUrl: './explore-video-hearing.component.html'
 })
-export class ExploreVideoHearingComponent extends IndividualBaseComponent {
+export class ExploreVideoHearingComponent {
 
-  constructor(journey: IndividualJourney, private deviceType: DeviceType) {
-    super(journey);
-  }
+  constructor(private journey: IndividualJourney, private deviceType: DeviceType) {}
 
   get isMobile(): boolean {
     return this.deviceType.isMobile();
+  }
+
+  continue() {
+    if (this.isMobile) {
+      this.journey.goto(IndividualJourneySteps.HearingAsParticipant);
+    } else {
+      this.journey.goto(IndividualJourneySteps.AccessToCameraAndMicrophone);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.spec.ts
@@ -1,8 +1,12 @@
 import { CommonIndividualComponentTests } from './../individual-base-component/individual-component-test-bed.spec';
 import { HelpTheCourtDecideComponent } from './help-the-court-decide.component';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('HelpTheCourtDecideComponent', () => {
-  it('can proceed when clicking next', () => {
-    CommonIndividualComponentTests.continuesWhenButtonIsPressed({ component: HelpTheCourtDecideComponent });
+  it(`goes to ${IndividualJourneySteps.AboutYou} when continue is pressed`, () => {
+    CommonIndividualComponentTests.goesToStepWhenButtonIsPressed(
+      IndividualJourneySteps.AboutYou,
+      { component: HelpTheCourtDecideComponent }
+      );
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.ts
@@ -1,10 +1,16 @@
-import { Component } from '@angular/core';
-import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
+import { IndividualJourney } from './../../individual-journey';
+import { Component } from '@angular/core'
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-help-the-court-decide',
   templateUrl: './help-the-court-decide.component.html',
   styles: []
 })
-export class HelpTheCourtDecideComponent extends IndividualBaseComponent {
+export class HelpTheCourtDecideComponent {
+  constructor(private journey: IndividualJourney) {}
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.AboutYou);
+  }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/help-the-court-decide/help-the-court-decide.component.ts
@@ -1,5 +1,5 @@
 import { IndividualJourney } from './../../individual-journey';
-import { Component } from '@angular/core'
+import { Component } from '@angular/core';
 import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-base.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-base.component.ts
@@ -12,10 +12,6 @@ export abstract class IndividualBaseComponent implements OnInit {
         this.journey.fail();
     }
 
-    continue(): void {
-        this.journey.next();
-    }
-
     get model(): IndividualSuitabilityModel {
         return this.journey.model;
     }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
@@ -74,7 +74,7 @@ export class IndividualJourneyStubs {
   public static get journeySpy(): jasmine.SpyObj<IndividualJourney> {
     return {
       model: IndividualJourneyStubs.model,
-      ...jasmine.createSpyObj<IndividualJourney>(['next'])
+      ...jasmine.createSpyObj<IndividualJourney>(['next', 'goto'])
     } as jasmine.SpyObj<IndividualJourney>;
   }
 }
@@ -89,7 +89,6 @@ export class IndividualJourneyComponentTestBed {
           ...(config.declarations || [])
         ],
         providers: [
-          { provide: IndividualSuitabilityModel, useClass: MutableIndividualSuitabilityModel },
           { provide: IndividualJourney, useValue: config.journey || IndividualJourneyStubs.default },
           ...(config.providers || [])
         ],

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
@@ -74,7 +74,7 @@ export class IndividualJourneyStubs {
   public static get journeySpy(): jasmine.SpyObj<IndividualJourney> {
     return {
       model: IndividualJourneyStubs.model,
-      ...jasmine.createSpyObj<IndividualJourney>(['next', 'goto'])
+      ...jasmine.createSpyObj<IndividualJourney>(['next', 'goto', 'submitQuestionnaire'])
     } as jasmine.SpyObj<IndividualJourney>;
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/individual-base-component/individual-component-test-bed.spec.ts
@@ -1,3 +1,4 @@
+import { JourneyStep } from './../../../base-journey/journey-step';
 import { IndividualJourneySteps } from '../../individual-journey-steps';
 import { MutableIndividualSuitabilityModel } from '../../mutable-individual-suitability.model';
 import { ComponentFixture } from '@angular/core/testing';
@@ -33,6 +34,21 @@ export class CommonIndividualComponentTests {
     fixture.detectChanges();
     new ContinuableComponentFixture(fixture).submitIsClicked();
     expect(journey.next).toHaveBeenCalled();
+  }
+
+  static goesToStepWhenButtonIsPressed<TComponent>(step: JourneyStep, config: ComponentTestBedConfiguration<TComponent>) {
+    const journey = jasmine.createSpyObj<IndividualJourney>(['goto']);
+    const fixture = IndividualJourneyComponentTestBed.createComponent({
+      component: config.component,
+      providers: config.providers,
+      imports: config.imports,
+      declarations: config.declarations,
+      journey: journey
+    });
+
+    fixture.detectChanges();
+    new ContinuableComponentFixture(fixture).submitIsClicked();
+    expect(journey.goto).toHaveBeenCalledWith(step);
   }
 }
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.html
@@ -3,7 +3,7 @@
     Getting an interpreter
   </h1>
 </div>
-<form [formGroup]="form" (ngSubmit)="continue()">
+<form [formGroup]="form" (ngSubmit)="submit()">
   <div id="form-container" class="govuk-form-group" [ngClass]="isFormInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
 
     <span id="error-message" class="govuk-error-message" *ngIf="isFormInvalid" i18n="@@interpreter_span_1">
@@ -42,7 +42,7 @@
     i18-bind-textArray="@@interpreter_textArray" bind-textArray="['For most types of hearing, you’ll need to find and pay for an interpreter yourself. For some types of hearing, the court may provide an interpreter for free of charge.  &lt;a href=&quot;https://www.gov.uk//get-interpreter-at-court-or-tribunal/&quot;class=&quot;govuk-link govuk-link--no-visited-state &quot;  target=&quot;_blank&quot;&gt;Find out more about getting an interpreter&lt;/a&gt;.']">
   </app-show-details>
 
-  <button class="govuk-button" (click)="continue()" i18n="@@interpreter_btn_continue" id="continue" type="button">Continue</button>
+  <button class="govuk-button" (click)="submit()" i18n="@@interpreter_btn_continue" id="continue" type="button">Continue</button>
 </form>
 
 <app-contact-us></app-contact-us>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.spec.ts
@@ -1,13 +1,18 @@
 import { CommonTests } from 'src/app/modules/base-journey/components/common-tests.spec';
 import { InterpreterComponent } from './interpreter.component';
-import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('InterpreterComponent', () => {
-  it('cannot proceed to next step until pressing choice, after submit value is bound', () => {
-    const fixture = IndividualJourneyComponentTestBed.createComponent({component: InterpreterComponent});
+  it(`cannot proceed to next step until pressing choice, then goes to ${IndividualJourneySteps.AccessToComputer}`, () => {
+    const journey = IndividualJourneyStubs.journeySpy;
+    const fixture = IndividualJourneyComponentTestBed.createComponent({
+      component: InterpreterComponent,
+      journey: journey
+    });
     CommonTests.cannotProceedUntilChoiceIsSelected(fixture);
 
-    // and value is bound
-    expect(fixture.componentInstance.model.interpreter).toBe(true);
+    expect(journey.model.interpreter).toBe(true);
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.AccessToComputer);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/interpreter/interpreter.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-interpreter',
@@ -20,5 +21,11 @@ export class InterpreterComponent extends SuitabilityChoicePageBaseComponent imp
 
   protected bindModel() {
     this.model.interpreter = this.choice.value;
+  }
+
+  submit() {
+    if (this.trySubmit()) {
+      this.journey.goto(IndividualJourneySteps.AccessToComputer);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/participant-view/participant-view.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/participant-view/participant-view.component.spec.ts
@@ -1,3 +1,5 @@
+import { JourneyStep } from './../../../base-journey/journey-step';
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { UserCameraViewComponent } from './../../components/user-camera-view/user-camera-view.component';
 import { ParticipantViewComponent } from './participant-view.component';
 import { MediaService } from '../../services/media.service';
@@ -29,6 +31,13 @@ describe('ParticipantViewComponent', () => {
       deviceType.isMobile.and.returnValue(false);
       component = new ParticipantViewComponent(journey, userMediaService, videoUrlService, deviceType);
       component.userCameraViewComponent = jasmine.createSpyObj<UserCameraViewComponent>(['setSource']);
+    });
+
+    it(`should continue to ${IndividualJourneySteps.HelpTheCourtDecide} when pressing continue`, () => {
+      let redirectedTo: JourneyStep;
+      journey.redirect.subscribe((step: JourneyStep) => redirectedTo = step);
+      component.continue();
+      expect(redirectedTo).toBe(IndividualJourneySteps.HelpTheCourtDecide);
     });
 
     it('should set the video source to a media stream when initialized', async () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/participant-view/participant-view.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/participant-view/participant-view.component.ts
@@ -1,3 +1,4 @@
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { Component, ViewChild, AfterContentInit, OnDestroy } from '@angular/core';
 import { IndividualJourney } from '../../individual-journey';
 import { MediaService } from '../../services/media.service';
@@ -20,9 +21,9 @@ export class ParticipantViewComponent extends VideoViewBaseComponent implements 
   stream: MediaStream;
   isMobile = false;
 
-  constructor(journey: IndividualJourney, private userMediaService: MediaService,
+  constructor(private journey: IndividualJourney, private userMediaService: MediaService,
     videoUrlService: VideoUrlService, private deviceType: DeviceType) {
-    super(journey, videoUrlService, VideoFiles.BeforeTheDay_ParticipantView);
+    super(videoUrlService, VideoFiles.BeforeTheDay_ParticipantView);
     this.isMobile = this.deviceType.isMobile();
   }
 
@@ -35,5 +36,9 @@ export class ParticipantViewComponent extends VideoViewBaseComponent implements 
 
   ngOnDestroy() {
     this.userMediaService.stopStream();
+  }
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.HelpTheCourtDecide);
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/use-camera-microphone/use-camera-microphone.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/use-camera-microphone/use-camera-microphone.component.spec.ts
@@ -1,9 +1,12 @@
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { UseCameraMicrophoneComponent } from './use-camera-microphone.component';
 import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
 import { MediaService } from '../../services/media.service';
 import { IndividualJourney } from '../../individual-journey';
 import { IndividualSuitabilityModel } from '../../individual-suitability.model';
 import { MutableIndividualSuitabilityModel } from '../../mutable-individual-suitability.model';
+import { By } from '@angular/platform-browser';
+import { tick, fakeAsync } from '@angular/core/testing';
 
 describe('UseCameraMicrophoneComponent', () => {
   let mediaService: jasmine.SpyObj<MediaService>;
@@ -15,24 +18,37 @@ describe('UseCameraMicrophoneComponent', () => {
     mediaService = jasmine.createSpyObj<MediaService>(['requestAccess']);
     individualJourney = {
       model: model,
-      ...jasmine.createSpyObj<IndividualJourney>(['next', 'fail'])
+      ...jasmine.createSpyObj<IndividualJourney>(['goto'])
     } as jasmine.SpyObj<IndividualJourney>;
   });
 
-  it('can be created', () => {
+  it(`should proceed to ${IndividualJourneySteps.HearingAsParticipant} after getting camera access`, fakeAsync(() => {
     const fixture = IndividualJourneyComponentTestBed.createComponent({
       component: UseCameraMicrophoneComponent,
-      providers: [ { provide: MediaService, useValue: mediaService } ]
+      providers: [ { provide: MediaService, useValue: mediaService } ],
+      journey: individualJourney
     });
     fixture.detectChanges();
-    expect(fixture.componentInstance).toBeTruthy();
-  });
 
-  it('should proceed with access denied on failure', async () => {
+    mediaService.requestAccess.and.returnValue(Promise.resolve(true));
+
+    const switchOnButton = fixture.debugElement.query(By.css('#switch-on-media'));
+    switchOnButton.nativeElement.click();
+    tick();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.mediaAccepted).toBe(true);
+    const continueButton = fixture.debugElement.query(By.css('#continue'));
+    continueButton.nativeElement.click();
+
+    expect(individualJourney.goto).toHaveBeenCalledWith(IndividualJourneySteps.HearingAsParticipant);
+  }));
+
+  it(`should proceed to ${IndividualJourneySteps.MediaAccessError} with access denied on failure`, async () => {
     mediaService.requestAccess.and.returnValue(Promise.resolve(false));
     const component = new UseCameraMicrophoneComponent(individualJourney, mediaService);
     await component.switchOnMedia();
-    expect(individualJourney.next).toHaveBeenCalled();
+    expect(individualJourney.goto).toHaveBeenCalledWith(IndividualJourneySteps.MediaAccessError);
     expect(model.mediaAccepted).toBe(false);
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/use-camera-microphone/use-camera-microphone.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/use-camera-microphone/use-camera-microphone.component.ts
@@ -1,3 +1,4 @@
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { Component } from '@angular/core';
 import { IndividualBaseComponent } from '../individual-base-component/individual-base.component';
 import { MediaService } from '../../services/media.service';
@@ -8,17 +9,20 @@ import { IndividualJourney } from '../../individual-journey';
   templateUrl: './use-camera-microphone.component.html',
   styles: []
 })
-export class UseCameraMicrophoneComponent extends IndividualBaseComponent {
+export class UseCameraMicrophoneComponent {
   mediaAccepted = false;
-  constructor(journey: IndividualJourney, private mediaAccess: MediaService) {
-    super(journey);
+  constructor(private journey: IndividualJourney, private mediaAccess: MediaService) {
   }
 
-  async switchOnMedia() {
+  async switchOnMedia(): Promise<void> {
     this.mediaAccepted = await this.mediaAccess.requestAccess();
     if (!this.mediaAccepted) {
-      this.model.mediaAccepted = false;
-      this.continue();
+      this.journey.model.mediaAccepted = false;
+      this.journey.goto(IndividualJourneySteps.MediaAccessError);
     }
+  }
+
+  continue() {
+    this.journey.goto(IndividualJourneySteps.HearingAsParticipant);
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.html
@@ -3,7 +3,7 @@
     Your computer
   </h1>
 </div>
-<form [formGroup]="form" (ngSubmit)="continue()">
+<form [formGroup]="form" (ngSubmit)="submit()">
   <div id="form-container" class="govuk-form-group"
     [ngClass]="isFormInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
 
@@ -52,7 +52,7 @@
     bind-textArray="['Don’t worry. You’ll have the chance to check that a video hearing will work on your computer. You can do this by watching a short video and confirming how well you could see and hear. This check is very simple and you don’t need to be an experienced computer user to do it.']">
   </app-show-details>
 
-  <button class="govuk-button" (click)="continue()" i18n="@@yourComputer_btn_continue" id="continue"
+  <button class="govuk-button" (click)="submit()" i18n="@@yourComputer_btn_continue" id="continue"
     type="button">Continue</button>
 </form>
 <app-contact-us></app-contact-us>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.spec.ts
@@ -1,3 +1,4 @@
+import { Component } from '@angular/core';
 import { CommonTests } from 'src/app/modules/base-journey/components/common-tests.spec';
 import { YourComputerComponent } from './your-computer.component';
 import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../individual-base-component/individual-component-test-bed.spec';
@@ -16,6 +17,16 @@ describe('YourComputerComponent', () => {
 
     expect(fixture.componentInstance.model.computer).toBe(true);
     expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.AboutYourComputer);
+  });
+
+  it(`should drop off to ${IndividualJourneySteps.ThankYou} if not having access to computer`, async () => {
+    const journey = IndividualJourneyStubs.journeySpy;
+    const component = new YourComputerComponent(journey);
+
+    component.choice.setValue(false);
+    await component.submit();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ThankYou);
+    expect(journey.submitQuestionnaire).toHaveBeenCalled();
   });
 
   it('should contain the scheduled date on init', () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.spec.ts
@@ -1,18 +1,21 @@
 import { CommonTests } from 'src/app/modules/base-journey/components/common-tests.spec';
 import { YourComputerComponent } from './your-computer.component';
 import { IndividualJourneyComponentTestBed, IndividualJourneyStubs } from '../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 describe('YourComputerComponent', () => {
 
-  it('cannot proceed to next step until pressing choice, after submit value is bound', () => {
+  it(`cannot proceed to next step until pressing choice, then goes to ${IndividualJourneySteps.AboutYourComputer}`, () => {
+    const journey = IndividualJourneyStubs.journeySpy;
     const fixture = IndividualJourneyComponentTestBed.createComponent({
-      component: YourComputerComponent
+      component: YourComputerComponent,
+      journey: journey
     });
 
     CommonTests.cannotProceedUntilChoiceIsSelected(fixture);
 
-    // and value is bound
     expect(fixture.componentInstance.model.computer).toBe(true);
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.AboutYourComputer);
   });
 
   it('should contain the scheduled date on init', () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-your-computer',
@@ -21,5 +22,11 @@ export class YourComputerComponent extends SuitabilityChoicePageBaseComponent im
 
   protected bindModel() {
     this.model.computer = this.choice.value;
+  }
+
+  submit() {
+    if (this.trySubmit()) {
+      this.journey.goto(IndividualJourneySteps.AboutYourComputer);
+    }
   }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-computer/your-computer.component.ts
@@ -24,8 +24,15 @@ export class YourComputerComponent extends SuitabilityChoicePageBaseComponent im
     this.model.computer = this.choice.value;
   }
 
-  submit() {
-    if (this.trySubmit()) {
+  async submit(): Promise<void> {
+    if (!this.trySubmit()) {
+      return;
+    }
+
+    if (this.model.computer === false) {
+      this.journey.submitQuestionnaire();
+      this.journey.goto(IndividualJourneySteps.ThankYou);
+    } else {
       this.journey.goto(IndividualJourneySteps.AboutYourComputer);
     }
   }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.html
@@ -5,7 +5,7 @@
     </h1>
 
 
-    <form [formGroup]="form" (ngSubmit)="continue()">
+    <form [formGroup]="form" (ngSubmit)="submit()">
 
       <div id="form-container" [ngClass]="isFormInvalid ? 'govuk-form-group--error' : 'govuk-form-group'">
         <div class="govuk-fieldset">
@@ -54,7 +54,7 @@
       </div>
 
       <div class="vh-top-20">
-        <button class="govuk-button" (click)="continue()" i18n="@@internetConnection_journey_btn_continue" id="continue"
+        <button class="govuk-button" (click)="submit()" i18n="@@internetConnection_journey_btn_continue" id="continue"
                 type="button">
           Continue
         </button>

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.spec.ts
@@ -1,9 +1,11 @@
+import { IndividualJourneyStubs } from './../individual-base-component/individual-component-test-bed.spec';
+import { IndividualJourneySteps } from './../../individual-journey-steps';
 import { CommonTests } from './../../../base-journey/components/common-tests.spec';
 import { YourInternetConnectionComponent } from './your-internet-connection.component';
 import { IndividualJourneyComponentTestBed } from '../individual-base-component/individual-component-test-bed.spec';
 
 describe('InterpreterComponent', () => {
-  it('cannot proceed to next step until pressing choice, after submit value is bound', () => {
+  it(`cannot proceed to next step until pressing choice, then goes to ${IndividualJourneySteps.AccessToRoom}`, () => {
     const fixture = IndividualJourneyComponentTestBed.createComponent({
       component: YourInternetConnectionComponent
     });
@@ -12,5 +14,15 @@ describe('InterpreterComponent', () => {
 
     // and value is bound
     expect(fixture.componentInstance.model.internet).toBe(true);
+  });
+
+  it(`should submit questionnaire and go to ${IndividualJourneySteps.ThankYou} if not having internet connection`, async () => {
+    const journey = IndividualJourneyStubs.journeySpy;
+    const component = new YourInternetConnectionComponent(journey);
+
+    component.choice.setValue(false);
+    await component.submit();
+    expect(journey.goto).toHaveBeenCalledWith(IndividualJourneySteps.ThankYou);
+    expect(journey.submitQuestionnaire).toHaveBeenCalled();
   });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/pages/your-internet-connection/your-internet-connection.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { SuitabilityChoicePageBaseComponent } from '../../components/suitability-choice-page-base.component';
 import { IndividualJourney } from '../../individual-journey';
+import { IndividualJourneySteps } from '../../individual-journey-steps';
 
 @Component({
   selector: 'app-your-internet-connection',
@@ -19,5 +20,18 @@ export class YourInternetConnectionComponent extends SuitabilityChoicePageBaseCo
 
   protected bindModel() {
     this.model.internet = this.choice.value;
+  }
+
+  async submit(): Promise<void> {
+    if (!this.trySubmit()) {
+      return;
+    }
+
+    if (this.model.internet === false) {
+      await this.journey.submitQuestionnaire();
+      this.journey.goto(IndividualJourneySteps.ThankYou);
+    } else {
+      this.journey.goto(IndividualJourneySteps.AccessToRoom);
+    }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4577

### Change description ###
**This is only an option, a suggestion to change, since it's a pretty big one**

I've moved all the transition logic out into the components instead. This will make it easier to extend and add logic into specific components. The drawback is that we lose the ability to control the overall journey in one place. The journey object (still not modified) would be reduced to only contain certain shared functionality, such as determining if the journey has been completed or not, the entry point and similar.

The journey actually works from start to finish with this.

Adding the self-test to this means to simply redirect to the first step in the self-test which would then go step-by-step. It can then finally navigate to the `ParticipantSteps.ThankYou` meaning there is a very loose coupling between the individual/representative journey and self-test journey.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
