### PR TITLE
Fix issue with closing video

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view/video-view.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/individual-journey/components/video-view/video-view.component.ts
@@ -56,10 +56,7 @@ export class VideoViewComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.stopPlaying();
-    if (this.videoTag.srcObject) {
-      this.videoTag.srcObject = null;
-    } else {
-      this.videoTag.src = null;
-    }
+    this.videoTag.removeAttribute('src');
+    this.videoTag.load();
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4577

### Change description ###
As I was testing the self-test updates for the individual journey I noticed an error appearing when navigating the pages. As I was worried it might have been introduced due to the changes in the story I debugged it and found that it was related to how we close down video streams:

<img width="1439" alt="before" src="https://user-images.githubusercontent.com/8461739/60664471-eef7b580-9e59-11e9-8953-019275be2309.png">

<img width="1415" alt="after" src="https://user-images.githubusercontent.com/8461739/60664474-f15a0f80-9e59-11e9-8e10-3343f43ebd96.png">

It will appear when you navigate _away_ from a page using the `video-view` component.

It turns out that we were closing down the stream in the wrong way causing it to actually request a video with `null` as the url. This turns out to be the right way to close it down:
https://stackoverflow.com/questions/3258587/how-to-properly-unload-destroy-a-video-element


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
