### PR TITLE
Vih 4578 representative journey reentry

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/hearing-selector.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/base-journey/hearing-selector.ts
@@ -1,0 +1,36 @@
+import { ParticipantSuitabilityModel } from 'src/app/modules/base-journey/participant-suitability.model';
+import { Logger } from 'src/app/services/logger';
+
+export class HearingSelector<TModel extends ParticipantSuitabilityModel> {
+    isDone: boolean;
+    selected: TModel;
+
+    constructor(
+        private isPendingDelegate: (model: TModel) => boolean,
+        private hearingModels: TModel[],
+        private logger: Logger
+    ) {
+        this.selected = this.selectHearing();
+        this.isDone = this.selected === null;
+    }
+
+    private selectHearing(): TModel {
+        const upcoming = this.hearingModels.filter(hearing => hearing.isUpcoming());
+        if (upcoming.length === 0) {
+        const pastHearings = this.hearingModels.map(h => h.hearing.id);
+        this.logger.event('Journey done: No upcoming hearings', { pastHearings });
+        return null;
+        }
+
+        const pending = upcoming.filter(u => this.isPendingDelegate(u));
+        if (pending.length === 0) {
+            const submittedHearings = upcoming.map(p => p.hearing.id);
+            this.logger.event('Journey done: All upcoming hearings completed.', { doneHearings: submittedHearings });
+            return null;
+        }
+
+        // sort upcoming on date and pick the earliest
+        pending.sort((u1, u2) => u1.hearing.scheduleDateTime.getTime() - u2.hearing.scheduleDateTime.getTime());
+        return pending[0];
+    }
+}

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
@@ -1,3 +1,4 @@
+import { TestLogger } from './../../../../services/logger.spec';
 import { MutableRepresentativeSuitabilityModel } from '../../mutable-representative-suitability.model';
 import { ComponentFixture } from '@angular/core/testing';
 import { Component } from '@angular/core';
@@ -26,7 +27,7 @@ export class RepresentativeJourneyStubs {
     const representativeStepsOrderFactory = new RepresentativeStepsOrderFactory();
     let submitService: jasmine.SpyObj<SubmitService>;
     submitService = jasmine.createSpyObj<SubmitService>(['submit']);
-    const journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService);
+    const journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService, TestLogger);
     journey.forSuitabilityAnswers([RepresentativeJourneyStubs.model]);
     journey.startAt(RepresentativeJourneySteps.AboutVideoHearings);
     return journey;

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
@@ -24,10 +24,9 @@ export interface RepresentativeComponentTestBedConfiguration<TComponent> extends
 export class RepresentativeJourneyStubs {
   public static get default(): RepresentativeJourney {
     // Journey with initialised model, so that it is accessible in steeps
-    const representativeStepsOrderFactory = new RepresentativeStepsOrderFactory();
     let submitService: jasmine.SpyObj<SubmitService>;
     submitService = jasmine.createSpyObj<SubmitService>(['submit']);
-    const journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService, TestLogger);
+    const journey = new RepresentativeJourney(submitService, TestLogger);
     journey.forSuitabilityAnswers([RepresentativeJourneyStubs.model]);
     journey.startAt(RepresentativeJourneySteps.AboutVideoHearings);
     return journey;

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/pages/representative-base-component/representative-journey-component-test-bed.spec.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
 
 import { RepresentativeJourney } from '../../representative-journey';
 import { RepresentativeSuitabilityModel } from '../../representative-suitability.model';
-import { Hearing } from '../../../base-journey/participant-suitability.model';
+import { Hearing, SelfTestAnswers } from '../../../base-journey/participant-suitability.model';
 import { RepresentativeStepsOrderFactory } from '../../representative-steps-order.factory';
 import {
   ComponentTestBedConfiguration,
@@ -35,6 +35,7 @@ export class RepresentativeJourneyStubs {
   public static get model(): RepresentativeSuitabilityModel {
     const model = new MutableRepresentativeSuitabilityModel();
     model.hearing = new Hearing('hearingId', new Date(2099, 1, 1, 12, 0));
+    model.selfTest = new SelfTestAnswers();
     return model;
   }
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -126,25 +126,25 @@ describe('RepresentativeJourney', () => {
     expect(redirected).toBe(Steps.AboutHearings);
   });
 
-  // it(`should enter journey at ${SelfTestJourneySteps.SameComputer} if completed questionnaire but not self-test`, () => {
-  //   journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
-  //   journey.jumpTo(Steps.AboutHearings);
-  //   expect(redirected).toBe(SelfTestJourneySteps.SameComputer);
-  // });
+  it(`should enter journey at ${SelfTestJourneySteps.SameComputer} if completed questionnaire but not self-test`, () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
+    journey.jumpTo(Steps.AboutHearings);
+    expect(redirected).toBe(SelfTestJourneySteps.SameComputer);
+  });
 
-  // it(`should redirect go to ${Steps.ThankYou} when having completed self test`, () => {
-  //   journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
-  //   journey.startAt(SelfTestJourneySteps.SameComputer);
+  it(`should redirect go to ${Steps.ThankYou} when having completed self test`, () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
+    journey.startAt(SelfTestJourneySteps.SameComputer);
 
-  //   // when completing self test journey
-  //   journey.model.selfTest.cameraWorking = true;
-  //   journey.model.selfTest.microphoneWorking = true;
-  //   journey.model.selfTest.sameComputer = true;
-  //   journey.model.selfTest.seeAndHearClearly = true;
+    // when completing self test journey
+    journey.model.selfTest.cameraWorking = true;
+    journey.model.selfTest.microphoneWorking = true;
+    journey.model.selfTest.sameComputer = true;
+    journey.model.selfTest.seeAndHearClearly = true;
 
-  //   // and going to
-  //   journey.jumpTo(Steps.ThankYou);
+    // and going to
+    journey.jumpTo(Steps.ThankYou);
 
-  //   expect(journey.step).toBe(Steps.ThankYou);
-  // });
+    expect(journey.step).toBe(Steps.ThankYou);
+  });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -128,8 +128,29 @@ describe('RepresentativeJourney', () => {
 
   it(`should enter journey at ${SelfTestJourneySteps.SameComputer} if completed questionnaire but not self-test`, () => {
     journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
-    journey.jumpTo(Steps.AboutHearings);
+    journey.jumpTo(Steps.AboutVideoHearings);
+    expect(journey.step).toBe(SelfTestJourneySteps.SameComputer);
     expect(redirected).toBe(SelfTestJourneySteps.SameComputer);
+  });
+
+  it(`can navigate to ${Steps.QuestionnaireCompleted} after dropping out on ${Steps.AccessToComputer}`, () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
+    journey.startAt(Steps.AccessToComputer);
+
+    journey.model.computer = false;
+    journey.jumpTo(Steps.QuestionnaireCompleted);
+
+    expect(journey.step).toBe(Steps.QuestionnaireCompleted);
+  });
+
+  it(`can navigate to ${Steps.ContactUs} after having seen ${Steps.QuestionnaireCompleted} post dropout`, () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
+    journey.model.computer = false;
+    journey.startAt(Steps.QuestionnaireCompleted);
+
+    journey.jumpTo(Steps.ContactUs);
+
+    expect(journey.step).toBe(Steps.ContactUs);
   });
 
   it(`should redirect go to ${Steps.ThankYou} when having completed self test`, () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -6,6 +6,7 @@ import { RepresentativeJourneySteps as Steps } from './representative-journey-st
 import { JourneyStep } from '../base-journey/journey-step';
 import { SubmitService } from './services/submit.service';
 import { SelfTestJourneySteps } from '../self-test-journey/self-test-journey-steps';
+import { TestLogger } from 'src/app/services/logger.spec';
 
 const tomorrow = new Date();
 tomorrow.setDate(tomorrow.getDate() + 1);
@@ -87,7 +88,7 @@ describe('RepresentativeJourney', () => {
 
   beforeEach(() => {
     redirected = null;
-    journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService);
+    journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService, TestLogger);
     journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
 
     journey.redirect.subscribe((s: JourneyStep) => redirected = s);

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -119,12 +119,6 @@ describe('RepresentativeJourney', () => {
     expect(journey.model.hearing.id).toBe('earlier upcoming hearing id');
   });
 
-  it('should redirect fo video app if any suitability answers have been answered', () => {
-    journey.forSuitabilityAnswers(suitabilityAnswers.completedAndUpcoming());
-    journey.jumpTo(Steps.AboutVideoHearings);
-    expect(redirected).toBe(Steps.GotoVideoApp);
-  });
-
   it('should run the journey from start for the first upcoming hearing that is not completed', () => {
     journey.forSuitabilityAnswers(suitabilityAnswers.completedAndUpcoming());
     expect(journey.model.hearing.id).toBe('another upcoming hearing id');

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -1,10 +1,11 @@
 import { MutableRepresentativeSuitabilityModel } from './mutable-representative-suitability.model';
 import { RepresentativeJourney } from './representative-journey';
-import { HasAccessToCamera, Hearing } from '../base-journey/participant-suitability.model';
+import { HasAccessToCamera, Hearing, SelfTestAnswers } from '../base-journey/participant-suitability.model';
 import { RepresentativeStepsOrderFactory } from './representative-steps-order.factory';
 import { RepresentativeJourneySteps as Steps } from './representative-journey-steps';
 import { JourneyStep } from '../base-journey/journey-step';
 import { SubmitService } from './services/submit.service';
+import { SelfTestJourneySteps } from '../self-test-journey/self-test-journey-steps';
 
 const tomorrow = new Date();
 tomorrow.setDate(tomorrow.getDate() + 1);
@@ -21,11 +22,12 @@ describe('RepresentativeJourney', () => {
   const getModelForHearing = (id: string, scheduledDateTime: Date) => {
     const model = new MutableRepresentativeSuitabilityModel();
     model.hearing = new Hearing(id, scheduledDateTime);
+    model.selfTest = new SelfTestAnswers();
     return model;
   };
 
-  const getCompletedModel = (id: string) => {
-    const model = getModelForHearing(id, tomorrow);
+  const getCompletedModel = (id: string, scheduledDateTime: Date = tomorrow) => {
+    const model = getModelForHearing(id, scheduledDateTime);
     model.aboutYou.answer = false;
     model.aboutYourClient.answer = true;
     model.hearingSuitability.answer = true;
@@ -33,25 +35,43 @@ describe('RepresentativeJourney', () => {
     model.camera = HasAccessToCamera.Yes;
     model.computer = true;
     model.room = true;
+
+    model.selfTest = new SelfTestAnswers({
+      cameraWorking: true,
+      seeAndHearClearly: true,
+      sameComputer: true,
+      microphoneWorking: true
+    });
+
+    return model;
+  };
+
+
+  const getOnlyCompletedQuestionnaire = (id: string, scheduledDateTime: Date) => {
+    const model = getCompletedModel(id, scheduledDateTime);
+    model.selfTest = new SelfTestAnswers();
     return model;
   };
 
   // helper test data
   const suitabilityAnswers = {
-    oneUpcomingHearing: [
+    oneUpcomingHearing: () => [
       getModelForHearing('upcoming hearing id', tomorrow)
     ],
-    twoUpcomingHearings: [
+    twoUpcomingHearings: () => [
       getModelForHearing('later upcoming hearing id', dayAfterTomorrow),
       getModelForHearing('earlier upcoming hearing id', tomorrow)
     ],
-    alreadyCompleted: [
+    alreadyCompleted: () => [
       getCompletedModel('completed hearing id')
     ],
-    completedAndUpcoming: [
-      getModelForHearing('upcoming hearing id', tomorrow),
+    completedAndUpcoming: () => [
+      getModelForHearing('upcoming hearing id', dayAfterTomorrow),
       getCompletedModel('completed hearing id'),
       getModelForHearing('another upcoming hearing id', tomorrow)
+    ],
+    withoutSelfTest: () => [
+      getOnlyCompletedQuestionnaire('completed questionnaire', tomorrow)
     ],
     noUpcomingHearings: []
   };
@@ -60,14 +80,10 @@ describe('RepresentativeJourney', () => {
   beforeEach(() => {
     redirected = null;
     journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService);
-    journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing);
+    journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
 
     journey.redirect.subscribe((s: JourneyStep) => redirected = s);
   });
-
-  const givenUserIsAtStep = (s: JourneyStep) => {
-    journey.jumpTo(s);
-  };
 
   it('should goto video app if there are no upcoming hearings', () => {
     journey.forSuitabilityAnswers(suitabilityAnswers.noUpcomingHearings);
@@ -77,7 +93,7 @@ describe('RepresentativeJourney', () => {
 
   it('should goto video app if trying to enter a finished journey', () => {
     // given journey that's finished
-    journey.forSuitabilityAnswers(suitabilityAnswers.alreadyCompleted);
+    journey.forSuitabilityAnswers(suitabilityAnswers.alreadyCompleted());
 
     // when trying to enter later in the journey
     journey.jumpTo(Steps.ClientAttendance);
@@ -85,6 +101,9 @@ describe('RepresentativeJourney', () => {
   });
 
   it('should stay where it is if trying to enter at the current step', () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
+    journey.startAt(Steps.AboutHearings);
+
     const currentStep = redirected;
     redirected = null;
 
@@ -96,13 +115,42 @@ describe('RepresentativeJourney', () => {
   });
 
   it('should run the story for the first upcoming hearing', () => {
-    journey.forSuitabilityAnswers(suitabilityAnswers.twoUpcomingHearings);
+    journey.forSuitabilityAnswers(suitabilityAnswers.twoUpcomingHearings());
     expect(journey.model.hearing.id).toBe('earlier upcoming hearing id');
   });
 
   it('should redirect fo video app if any suitability answers have been answered', () => {
-    journey.forSuitabilityAnswers(suitabilityAnswers.completedAndUpcoming);
+    journey.forSuitabilityAnswers(suitabilityAnswers.completedAndUpcoming());
     journey.jumpTo(Steps.AboutVideoHearings);
     expect(redirected).toBe(Steps.GotoVideoApp);
   });
+
+  it('should run the journey from start for the first upcoming hearing that is not completed', () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.completedAndUpcoming());
+    expect(journey.model.hearing.id).toBe('another upcoming hearing id');
+    journey.startAt(Steps.AboutHearings);
+    expect(redirected).toBe(Steps.AboutHearings);
+  });
+
+  // it(`should enter journey at ${SelfTestJourneySteps.SameComputer} if completed questionnaire but not self-test`, () => {
+  //   journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
+  //   journey.jumpTo(Steps.AboutHearings);
+  //   expect(redirected).toBe(SelfTestJourneySteps.SameComputer);
+  // });
+
+  // it(`should redirect go to ${Steps.ThankYou} when having completed self test`, () => {
+  //   journey.forSuitabilityAnswers(suitabilityAnswers.withoutSelfTest());
+  //   journey.startAt(SelfTestJourneySteps.SameComputer);
+
+  //   // when completing self test journey
+  //   journey.model.selfTest.cameraWorking = true;
+  //   journey.model.selfTest.microphoneWorking = true;
+  //   journey.model.selfTest.sameComputer = true;
+  //   journey.model.selfTest.seeAndHearClearly = true;
+
+  //   // and going to
+  //   journey.jumpTo(Steps.ThankYou);
+
+  //   expect(journey.step).toBe(Steps.ThankYou);
+  // });
 });

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -46,6 +46,11 @@ describe('RepresentativeJourney', () => {
     return model;
   };
 
+  const getDroppedOutModel = (id: string) => {
+    const model = getModelForHearing(id, tomorrow);
+    model.computer = false;
+    return model;
+  };
 
   const getOnlyCompletedQuestionnaire = (id: string, scheduledDateTime: Date) => {
     const model = getCompletedModel(id, scheduledDateTime);
@@ -69,6 +74,9 @@ describe('RepresentativeJourney', () => {
       getModelForHearing('upcoming hearing id', dayAfterTomorrow),
       getCompletedModel('completed hearing id'),
       getModelForHearing('another upcoming hearing id', tomorrow)
+    ],
+    droppedOutFromQuestionnaire: () => [
+      getDroppedOutModel('dropped out hearing')
     ],
     withoutSelfTest: () => [
       getOnlyCompletedQuestionnaire('completed questionnaire', tomorrow)
@@ -151,6 +159,13 @@ describe('RepresentativeJourney', () => {
     journey.jumpTo(Steps.ContactUs);
 
     expect(journey.step).toBe(Steps.ContactUs);
+  });
+
+  it(`should redirect to videoapp if having dropped out from questionnaire`, () => {
+    journey.forSuitabilityAnswers(suitabilityAnswers.droppedOutFromQuestionnaire());
+    journey.startAt(Steps.AboutVideoHearings);
+
+    expect(redirected).toBe(Steps.GotoVideoApp);
   });
 
   it(`should redirect go to ${Steps.ThankYou} when having completed self test`, () => {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.spec.ts
@@ -84,11 +84,10 @@ describe('RepresentativeJourney', () => {
     ],
     noUpcomingHearings: []
   };
-  const representativeStepsOrderFactory = new RepresentativeStepsOrderFactory();
 
   beforeEach(() => {
     redirected = null;
-    journey = new RepresentativeJourney(representativeStepsOrderFactory, submitService, TestLogger);
+    journey = new RepresentativeJourney(submitService, TestLogger);
     journey.forSuitabilityAnswers(suitabilityAnswers.oneUpcomingHearing());
 
     journey.redirect.subscribe((s: JourneyStep) => redirected = s);

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -1,3 +1,4 @@
+import { HearingSelector } from './../base-journey/hearing-selector';
 import { Logger } from 'src/app/services/logger';
 import { EventEmitter, Injectable } from '@angular/core';
 import { JourneyBase } from '../base-journey/journey-base';
@@ -43,25 +44,10 @@ export class RepresentativeJourney extends JourneyBase {
   }
 
   forSuitabilityAnswers(suitabilityAnswers: RepresentativeSuitabilityModel[]) {
-    const upcoming = suitabilityAnswers.filter(hearing => hearing.isUpcoming());
-    if (upcoming.length === 0) {
-      const pastHearings = suitabilityAnswers.map(h => h.hearing.id);
-      this.logger.event('Journey done: No upcoming hearings', { pastHearings });
-      this.isDone = true;
-      return;
-    }
-
-    const pending = upcoming.filter(u => !u.isCompleted());
-    if (pending.length === 0) {
-      const submittedHearings = upcoming.map(p => p.hearing.id);
-      this.logger.event('Journey done: All upcoming hearings completed.', { doneHearings: submittedHearings });
-      this.isDone = true;
-      return;
-    }
-
-    // sort upcoming on date and pick the earliest
-    pending.sort((u1, u2) => u1.hearing.scheduleDateTime.getTime() - u2.hearing.scheduleDateTime.getTime());
-    this.currentModel = pending[0];
+    const isPending = (answers: RepresentativeSuitabilityModel) => !answers.isCompleted();
+    const selector = new HearingSelector(isPending, suitabilityAnswers, this.logger);
+    this.isDone = selector.isDone;
+    this.currentModel = selector.selected;
   }
 
   startAt(step: JourneyStep) {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -17,6 +17,18 @@ export class RepresentativeJourney extends JourneyBase {
   private currentModel: RepresentativeSuitabilityModel;
   private isDone: boolean;
 
+  private readonly questionnairePages = [
+    RepresentativeJourneySteps.AboutVideoHearings,
+    RepresentativeJourneySteps.AboutYouAndYourClient,
+    RepresentativeJourneySteps.AboutYou,
+    RepresentativeJourneySteps.AccessToRoom,
+    RepresentativeJourneySteps.AboutYourClient,
+    RepresentativeJourneySteps.ClientAttendance,
+    RepresentativeJourneySteps.HearingSuitability,
+    RepresentativeJourneySteps.AccessToComputer,
+    RepresentativeJourneySteps.AboutYourComputer
+  ];
+
   constructor(private stepsFactory: RepresentativeStepsOrderFactory, private submitService: SubmitService) {
     super();
     this.redirect.subscribe((step: JourneyStep) => this.currentStep = step);
@@ -49,7 +61,7 @@ export class RepresentativeJourney extends JourneyBase {
     this.assertInitialised();
     if (this.isDone) {
       this.goto(RepresentativeJourneySteps.GotoVideoApp);
-    } else if (this.isQuestionnaireCompleted() && !this.isSelfTestStep(step)) {
+    } else if (this.isQuestionnaireCompleted() && this.isQuestionnaireStep(step)) {
       this.goto(SelfTestJourneySteps.SameComputer);
     } else {
       this.goto(step);
@@ -57,13 +69,12 @@ export class RepresentativeJourney extends JourneyBase {
   }
 
   private isQuestionnaireCompleted(): boolean {
-    return this.currentModel.computer !== undefined
-      || (this.currentModel.camera === HasAccessToCamera.NotSure || this.currentModel.camera === HasAccessToCamera.Yes);
+    // if we've dropped out on not having access to a computer or if we've answered the camera question which is the last
+    return this.currentModel.computer === false || this.currentModel.camera !== undefined;
   }
 
-  private isSelfTestStep(step: JourneyStep): boolean {
-    // Include thank you as it comes straight after self-test
-    return step === RepresentativeJourneySteps.ThankYou || SelfTestJourneySteps.GetAll().indexOf(step) !== -1;
+  private isQuestionnaireStep(step: JourneyStep): boolean {
+    return this.questionnairePages.indexOf(step) >= 0;
   }
 
   get model(): RepresentativeSuitabilityModel {
@@ -88,7 +99,7 @@ export class RepresentativeJourney extends JourneyBase {
     this.assertInitialised();
     if (this.isDone) {
       this.goto(RepresentativeJourneySteps.GotoVideoApp);
-    } else if (this.isQuestionnaireCompleted() && !this.isSelfTestStep(position)) {
+    } else if (this.isQuestionnaireCompleted() && this.isQuestionnaireStep(position)) {
       this.goto(SelfTestJourneySteps.SameComputer);
     } else {
       this.currentStep = position;

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -13,7 +13,6 @@ import { SelfTestJourneySteps } from '../self-test-journey/self-test-journey-ste
 export class RepresentativeJourney extends JourneyBase {
   static readonly initialStep = RepresentativeJourneySteps.AboutVideoHearings;
   readonly redirect: EventEmitter<JourneyStep> = new EventEmitter();
-  stepOrder: Array<JourneyStep>;
   private currentStep: JourneyStep = RepresentativeJourneySteps.NotStarted;
   private currentModel: RepresentativeSuitabilityModel;
   private isDone: boolean;
@@ -30,13 +29,9 @@ export class RepresentativeJourney extends JourneyBase {
     RepresentativeJourneySteps.AboutYourComputer
   ];
 
-  constructor(
-    private stepsFactory: RepresentativeStepsOrderFactory,
-    private submitService: SubmitService,
-    private logger: Logger) {
+  constructor(private submitService: SubmitService, private logger: Logger) {
     super();
     this.redirect.subscribe((step: JourneyStep) => this.currentStep = step);
-    this.stepOrder = this.stepsFactory.stepOrder();
   }
 
   get step(): JourneyStep {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -46,7 +46,7 @@ export class RepresentativeJourney extends JourneyBase {
       return;
     }
 
-    const pending = upcoming.filter(u => u.selfTest !== undefined && !u.selfTest.isCompleted());
+    const pending = upcoming.filter(u => !u.isCompleted());
     if (pending.length === 0) {
       this.isDone = true;
       return;

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-journey.ts
@@ -32,16 +32,15 @@ export class RepresentativeJourney extends JourneyBase {
       return;
     }
 
-    for (const answers of suitabilityAnswers) {
-      if (this.isSuitabilityAnswersComplete(answers)) {
-        this.isDone = true;
-        return;
-      }
+    const pending = upcoming.filter(u => u.selfTest !== undefined && !u.selfTest.isCompleted());
+    if (pending.length === 0) {
+      this.isDone = true;
+      return;
     }
 
     // sort upcoming on date and pick the earliest
-    upcoming.sort((u1, u2) => u1.hearing.scheduleDateTime.getTime() - u2.hearing.scheduleDateTime.getTime());
-    this.currentModel = upcoming[0];
+    pending.sort((u1, u2) => u1.hearing.scheduleDateTime.getTime() - u2.hearing.scheduleDateTime.getTime());
+    this.currentModel = pending[0];
   }
 
   startAt(step: JourneyStep) {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.spec.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.spec.ts
@@ -1,0 +1,35 @@
+import { MutableRepresentativeSuitabilityModel } from './mutable-representative-suitability.model';
+import { SelfTestAnswers } from '../base-journey/participant-suitability.model';
+
+describe('RepresentativeSuitabilityModel', () => {
+    it('is completed if not having access to a computer', () => {
+        const model = new MutableRepresentativeSuitabilityModel();
+        model.aboutYou.answer = false;
+        model.aboutYourClient.answer = false;
+        model.clientAttendance = false;
+        model.hearingSuitability.answer = false;
+        model.room = true;
+        model.selfTest = new SelfTestAnswers();
+        model.computer = false;
+
+        expect(model.isCompleted()).toBe(true);
+    });
+
+    it('is completed if selftest is completed', () => {
+        const model = new MutableRepresentativeSuitabilityModel();
+        model.aboutYou.answer = false;
+        model.aboutYourClient.answer = false;
+        model.clientAttendance = false;
+        model.hearingSuitability.answer = false;
+        model.room = true;
+        model.computer = true;
+        model.selfTest = new SelfTestAnswers({
+            cameraWorking: true,
+            seeAndHearClearly: true,
+            sameComputer: true,
+            microphoneWorking: true
+        });
+
+        expect(model.isCompleted()).toBe(true);
+    });
+});

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.ts
@@ -1,3 +1,4 @@
+import { HasAccessToCamera } from './../base-journey/participant-suitability.model';
 import { ParticipantSuitabilityModel, SuitabilityAnswer } from '../base-journey/participant-suitability.model';
 
 /**
@@ -7,4 +8,9 @@ export abstract class RepresentativeSuitabilityModel extends ParticipantSuitabil
     aboutYourClient: SuitabilityAnswer;
     clientAttendance: boolean;
     hearingSuitability: SuitabilityAnswer;
+
+    isCompleted(): boolean {
+        const droppedOff = this.camera === HasAccessToCamera.No || this.computer === false;
+        return droppedOff || (this.selfTest && this.selfTest.isCompleted());
+    }
 }

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/representative-journey/representative-suitability.model.ts
@@ -11,6 +11,6 @@ export abstract class RepresentativeSuitabilityModel extends ParticipantSuitabil
 
     isCompleted(): boolean {
         const droppedOff = this.camera === HasAccessToCamera.No || this.computer === false;
-        return droppedOff || (this.selfTest && this.selfTest.isCompleted());
+        return droppedOff || (this.selfTest !== undefined && this.selfTest.isCompleted());
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-4578

### Change description ###
Added in the re-entry to allow a user to switch device mid-journey. Logging out from mobile for example and then continuing on self-test on re-entry.

There were some changes in the test, especially one about blocking the representative to do a 2nd hearing which I believe was simply wrong.

Whoever reviews, please do help me have another think through if those test conditions are correct.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
