### PR TITLE
allowed sub domain for visual studio in content security policy

### DIFF
--- a/ServiceWebsite/ServiceWebsite/Web.config
+++ b/ServiceWebsite/ServiceWebsite/Web.config
@@ -10,7 +10,7 @@
         </security>
         <httpProtocol>
             <customHeaders>
-              <add name="Content-Security-Policy" value="default-src 'self'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.msecnd.net/; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self' https://www.bing.com https://.visualstudio.com https://*.self-test.hearings.hmcts.net; media-src 'self' https://*.blob.core.windows.net" />
+              <add name="Content-Security-Policy" value="default-src 'self'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.msecnd.net/; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self' https://www.bing.com https://*.visualstudio.com https://*.self-test.hearings.hmcts.net; media-src 'self' https://*.blob.core.windows.net" />
             <remove name="X-Powered-By" />
             </customHeaders>
         </httpProtocol>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/VIH-4846

### Change description ###

included sub domains for visualstudio.com in content security policy

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
