### PR TITLE
VIH-4902 / VIH-4910: Adding the security response headers

### DIFF
--- a/ServiceWebsite/ServiceWebsite/Program.cs
+++ b/ServiceWebsite/ServiceWebsite/Program.cs
@@ -13,6 +13,7 @@ namespace ServiceWebsite
         public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {
             return WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(c => c.AddServerHeader = false)
                 .UseStartup<Startup>();
         }
     }

--- a/ServiceWebsite/ServiceWebsite/Startup.cs
+++ b/ServiceWebsite/ServiceWebsite/Startup.cs
@@ -120,7 +120,6 @@ namespace ServiceWebsite
             {
                 // this will route any unhandled exceptions to the angular error page
                 app.UseExceptionHandler(Urls.Error);
-
                 app.UseHsts();
                 app.UseHttpsRedirection();
             }
@@ -134,16 +133,16 @@ namespace ServiceWebsite
                 .AllowAnyHeader());
 
             app.UseMiddleware<ExceptionMiddleware>();
-
-
-
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
 
+            // HTTP Response Headers
             app.UseXContentTypeOptions();
             app.UseReferrerPolicy(opts => opts.NoReferrer());
             app.UseXXssProtection(options => options.EnabledWithBlockMode());
             app.UseNoCacheHttpHeaders();
+            app.UseHsts(options => options.MaxAge(365).IncludeSubdomains());
+            app.UseXfo(options => options.SameOrigin());
 
             app.UseMvc(routes =>
             {

--- a/ServiceWebsite/ServiceWebsite/Web.config
+++ b/ServiceWebsite/ServiceWebsite/Web.config
@@ -8,12 +8,6 @@
         <security>
             <requestFiltering removeServerHeader="true" />
         </security>
-        <httpProtocol>
-            <customHeaders>
-              <add name="Content-Security-Policy" value="default-src 'self'; style-src https://fonts.googleapis.com https://fonts.gstatic.com 'unsafe-inline' 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.msecnd.net/; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data:; connect-src 'self' https://www.bing.com https://*.visualstudio.com https://*.self-test.hearings.hmcts.net; media-src 'self' https://*.blob.core.windows.net" />
-            <remove name="X-Powered-By" />
-            </customHeaders>
-        </httpProtocol>
         <rewrite>
           <outboundRules>
             <rule name="Add Strict-Transport-Security when HTTPS" enabled="true">


### PR DESCRIPTION
Also removed               <add name="Content-Security-Policy" value="default-src 'self'; style-src https://fonts.googl.... from Web.config as headers here are not acted upon

https://tools.hmcts.net/jira/browse/VIH-4910
https://tools.hmcts.net/jira/browse/VIH-4902

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
