### PR TITLE
VIH-5435: Disable "continue" button on self test page

### DIFF
--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.html
@@ -44,7 +44,7 @@
 
 <div>
 
-  <input type="button" i18n="@@test_your_equipment_btn_next" class="govuk-button govuk-!-margin-right-1" (click)="continue()"
+  <input type="button" i18n="@@test_your_equipment_btn_next" class="govuk-button govuk-!-margin-right-1" (click)="continue()" [disabled]="!didTestComplete"
          id="continue" role="button" value="Continue" alt="Continue" [ngClass]="testCompleted() ? 'govuk-button' : 'govuk-button--disabled'" />
 
   <input type="button" i18n="@@test_your_equipment_btn_replay" class="govuk-button" (click)="replayVideo()"

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.html
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.html
@@ -37,7 +37,7 @@
 <div class="govuk-grid-row govuk-!-margin-top-6">
   <div class="govuk-grid-column-full">
     <p class="govuk-body" i18n="@@test_your_equipment_p_2">
-      When the video has ended, answer a few questions to confirm your microphone and camera are working.
+      You can continue once the video has ended. You'll be asked 3 questions to confirm your microphone and camera are working.
     </p>
   </div>
 </div>
@@ -45,7 +45,7 @@
 <div>
 
   <input type="button" i18n="@@test_your_equipment_btn_next" class="govuk-button govuk-!-margin-right-1" (click)="continue()"
-         id="continue" role="button" value="Continue" alt="Continue" />
+         id="continue" role="button" value="Continue" alt="Continue" [ngClass]="testCompleted() ? 'govuk-button' : 'govuk-button--disabled'" />
 
   <input type="button" i18n="@@test_your_equipment_btn_replay" class="govuk-button" (click)="replayVideo()"
          id="replay-video" value="Re-play the video message" alt="Re-play the video message" role="button" />

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
@@ -196,7 +196,6 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
 
   disconnectHandleEvent(reason) {
     this.displayFeed = false;
-
     this.logger.error('(disconnectHandleEvent -> Disconnected from pexip.)', new Error(reason),
       { hearingId: this.model.hearing.id, participantId: this.model.participantId });
 

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
@@ -201,8 +201,8 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
       { hearingId: this.model.hearing.id, participantId: this.model.participantId });
 
     if (reason === 'Conference terminated by another participant') {
-      this.didTestComplete = true;
       this.retrieveSelfTestScore();
+      this.didTestComplete = true;
     }
   }
 
@@ -295,6 +295,10 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
   async onMediaDeviceChangeCancelled() {
     this.displayDeviceChangeModal = false;
     this.call();
+  }
+
+  testCompleted(): boolean {
+    return this.didTestComplete;
   }
 
   continue() {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
@@ -201,8 +201,8 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
 
     if (reason === 'Conference terminated by another participant') {
       this.retrieveSelfTestScore();
-      this.didTestComplete = true;
     }
+    this.didTestComplete = true;    
   }
 
   disconnect() {

--- a/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
+++ b/ServiceWebsite/ServiceWebsite/ClientApp/src/app/modules/self-test-journey/pages/test-your-equipment/test-your-equipment.component.ts
@@ -202,7 +202,7 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
     if (reason === 'Conference terminated by another participant') {
       this.retrieveSelfTestScore();
     }
-    this.didTestComplete = true;    
+    this.didTestComplete = true;
   }
 
   disconnect() {
@@ -240,7 +240,7 @@ export class TestYourEquipmentComponent extends SuitabilityChoicePageBaseCompone
 
       this.logger.error('(retrieveSelfTestScore -> Error to get self test score)', new Error(error),
         { hearingId: this.model.hearing.id, participantId: this.model.participantId });
-        this.logger.event('telemetry:serviceweb:any:selftest:score:none');
+      this.logger.event('telemetry:serviceweb:any:selftest:score:none');
     });
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/VIH-5435
### Change description ###
Disable "continue" button on self test page until self-test score is retrieved
modified the component to keep the continue button disabled until the test score is retrieved.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
