### PR TITLE
[VIH-5255] added timeouts to kinly videos

### DIFF
--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/Individual/ExploreCourtBuildingSteps.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/Individual/ExploreCourtBuildingSteps.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using AcceptanceTests.Common.Driver.Browser;
-using AcceptanceTests.Common.Driver.Helpers;
 using AcceptanceTests.Common.PageObject.Helpers;
 using AcceptanceTests.Common.Test.Helpers;
 using AcceptanceTests.Common.Test.Steps;
@@ -13,6 +12,7 @@ namespace ServiceWebsite.AcceptanceTests.Steps.Individual
     [Binding]
     public class ExploreCourtBuildingSteps : ISteps
     {
+        private const int ExtraTimeForVideoToLoad = 30;
         private readonly Dictionary<string, UserBrowser> _browsers;
         private readonly TestContext _c;
 
@@ -31,7 +31,7 @@ namespace ServiceWebsite.AcceptanceTests.Steps.Individual
         [Then(@"the exploring the court building video begins to play")]
         public void ThenTheExploringTheCourtBuildingVideoBeginsToPlay()
         {
-            new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Feed(ExploreCourtBuildingPage.Video);
+            new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Retries(ExtraTimeForVideoToLoad).Feed(ExploreCourtBuildingPage.Video);
         }
     }
 }

--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/Individual/ExploreCourtBuildingSteps.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/Individual/ExploreCourtBuildingSteps.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using AcceptanceTests.Common.Driver.Browser;
+using AcceptanceTests.Common.Driver.Helpers;
+using AcceptanceTests.Common.Driver.Support;
 using AcceptanceTests.Common.PageObject.Helpers;
 using AcceptanceTests.Common.Test.Helpers;
 using AcceptanceTests.Common.Test.Steps;
@@ -31,6 +33,11 @@ namespace ServiceWebsite.AcceptanceTests.Steps.Individual
         [Then(@"the exploring the court building video begins to play")]
         public void ThenTheExploringTheCourtBuildingVideoBeginsToPlay()
         {
+            if (_c.ServiceWebConfig.TestConfig.TargetBrowser == TargetBrowser.Chrome ||
+                _c.ServiceWebConfig.TestConfig.TargetBrowser == TargetBrowser.ChromeMac)
+            {
+                _browsers[_c.CurrentUser.Key].Driver.WaitUntilVisible(ExploreCourtBuildingPage.Video).Click();
+            }
             new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Retries(ExtraTimeForVideoToLoad).Feed(ExploreCourtBuildingPage.Video);
         }
     }

--- a/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/SelfTest/TestYourEquipmentSteps.cs
+++ b/ServiceWebsite/ServiceWebsite.AcceptanceTests/Steps/SelfTest/TestYourEquipmentSteps.cs
@@ -15,6 +15,7 @@ namespace ServiceWebsite.AcceptanceTests.Steps.SelfTest
     [Binding]
     public class TestYourEquipmentSteps : ISteps
     {
+        private const int ExtraTimeForVideoToLoad = 30;
         private const int VideoLength = 90;
         private readonly Dictionary<string, UserBrowser> _browsers;
         private readonly TestContext _c;
@@ -44,7 +45,7 @@ namespace ServiceWebsite.AcceptanceTests.Steps.SelfTest
         [Then(@"the Test Your Equipment video begins to play")]
         public void TheVideoBeginsToPlay()
         {
-            new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Feed(TestYourEquipmentPage.IncomingStream);
+            new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Retries(ExtraTimeForVideoToLoad).Feed(TestYourEquipmentPage.IncomingStream);
             new VerifyVideoIsPlayingBuilder(_browsers[_c.CurrentUser.Key]).Feed(TestYourEquipmentPage.SelfView);
         }
     }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] tests have been updated / new tests has been added (if needed)

### Change description ###
- Fixes for broken Chrome and Firefox tests
- Explore Court video is no longer autoplaying on latest version of Chrome so added a workaround

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
