### PR TITLE
VIH-7987 removed api-bintray from nuget.config

### DIFF
--- a/ServiceWebsite/nuget.config
+++ b/ServiceWebsite/nuget.config
@@ -11,7 +11,6 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="vh-packages" value="https://pkgs.dev.azure.com/hmctsreform/VirtualHearings/_packaging/vh-packages/nuget/v3/index.json" />
-    <add key="govuk-bintray" value="https://api.bintray.com/nuget/gov-uk-notify/nuget" />
   </packageSources>
 
   <!-- Default Package Sources that are disabled by default. -->


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Noticed api-bintray (which caused issues on the sds prep branch) was still in master. Removed now.

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
